### PR TITLE
PR : Feat/attempt-processing-step (#75)

### DIFF
--- a/src/main/java/com/imyme/mine/domain/card/dto/AttemptDetailResponse.java
+++ b/src/main/java/com/imyme/mine/domain/card/dto/AttemptDetailResponse.java
@@ -18,6 +18,7 @@ public record AttemptDetailResponse(
     Short attemptNo,
     Long cardId,
     String status,
+    AttemptProcessingStep step,
     String audioUrl,
     Integer durationSeconds,
     String sttText,
@@ -56,6 +57,7 @@ public record AttemptDetailResponse(
             null,
             null,
             null,
+            null,
             attempt.getCreatedAt(),
             null,
             null,
@@ -85,6 +87,7 @@ public record AttemptDetailResponse(
             attempt.getAttemptNo(),
             attempt.getCard().getId(),
             attempt.getStatus().name(),
+            null,
             attempt.getAudioUrl(),
             null,
             null,
@@ -110,14 +113,18 @@ public record AttemptDetailResponse(
      * - estimated_completion_at: 예상 완료 시간
      * - retry_after_seconds: 폴링 간격 (3초)
      */
-    public static AttemptDetailResponse fromProcessing(CardAttempt attempt) {
+    public static AttemptDetailResponse fromProcessing(CardAttempt attempt, AttemptProcessingStep step) {
         LocalDateTime estimatedCompletion = attempt.getSubmittedAt().plusMinutes(3);
+        String message = (step == AttemptProcessingStep.AUDIO_ANALYSIS)
+            ? "AI 음성 분석 중입니다."
+            : "AI 피드백 분석 중입니다.";
 
         return new AttemptDetailResponse(
             attempt.getId(),
             attempt.getAttemptNo(),
             attempt.getCard().getId(),
             attempt.getStatus().name(),
+            step,
             attempt.getAudioUrl(),
             null,
             null,
@@ -133,7 +140,7 @@ public record AttemptDetailResponse(
             null,
             null,
             null,
-            "AI 피드백 분석 중입니다."
+            message
         );
     }
 
@@ -149,6 +156,7 @@ public record AttemptDetailResponse(
             attempt.getAttemptNo(),
             attempt.getCard().getId(),
             attempt.getStatus().name(),
+            null,
             attempt.getAudioUrl(),
             attempt.getDurationSeconds(),
             attempt.getSttText(),
@@ -180,6 +188,7 @@ public record AttemptDetailResponse(
             attempt.getAttemptNo(),
             attempt.getCard().getId(),
             attempt.getStatus().name(),
+            null,
             attempt.getAudioUrl(),
             null,
             null,
@@ -193,7 +202,7 @@ public record AttemptDetailResponse(
             null,
             null,
             null,
-            attempt.getErrorMessage() != null ? attempt.getErrorMessage() : "알 수 없는 오류가 발생했습니다.",
+            attempt.getErrorMessage() != null ? attempt.getErrorMessage() : "UNKNOWN_ERROR",
             true,
             "오류가 발생했습니다. 다시 시도해주세요."
         );
@@ -213,6 +222,7 @@ public record AttemptDetailResponse(
             attempt.getAttemptNo(),
             attempt.getCard().getId(),
             attempt.getStatus().name(),
+            null,
             null,
             null,
             null,

--- a/src/main/java/com/imyme/mine/domain/card/dto/AttemptProcessingStep.java
+++ b/src/main/java/com/imyme/mine/domain/card/dto/AttemptProcessingStep.java
@@ -1,0 +1,9 @@
+package com.imyme.mine.domain.card.dto;
+
+/**
+ * 학습 시도 진행 단계 (PROCESSING 상태 세분화)
+ */
+public enum AttemptProcessingStep {
+    AUDIO_ANALYSIS,       // STT 변환 중
+    FEEDBACK_GENERATION   // AI 피드백 생성 중
+}

--- a/src/main/java/com/imyme/mine/domain/card/entity/CardAttempt.java
+++ b/src/main/java/com/imyme/mine/domain/card/entity/CardAttempt.java
@@ -93,6 +93,10 @@ public class CardAttempt {
         this.finishedAt = LocalDateTime.now();
     }
 
+    public void recordSttResult(String sttText) {
+        this.sttText = sttText;
+    }
+
     public void fail(String errorMessage) {
         this.errorMessage = errorMessage;
         this.status = AttemptStatus.FAILED;

--- a/src/main/java/com/imyme/mine/domain/card/service/AttemptService.java
+++ b/src/main/java/com/imyme/mine/domain/card/service/AttemptService.java
@@ -4,6 +4,7 @@ import com.imyme.mine.domain.ai.client.AiServerClient;
 import com.imyme.mine.domain.card.dto.AttemptCreateRequest;
 import com.imyme.mine.domain.card.dto.AttemptCreateResponse;
 import com.imyme.mine.domain.card.dto.AttemptDetailResponse;
+import com.imyme.mine.domain.card.dto.AttemptProcessingStep;
 import com.imyme.mine.domain.card.dto.UploadCompleteRequest;
 import com.imyme.mine.domain.card.dto.UploadCompleteResponse;
 import com.imyme.mine.domain.card.entity.AttemptStatus;
@@ -116,6 +117,7 @@ public class AttemptService {
         }
 
         attempt.markUploaded(request.audioUrl(), request.durationSeconds());
+        attempt.startProcessing();
 
         // STT (Speech-to-Text) 처리 - 동기 호출
         try {
@@ -130,8 +132,8 @@ public class AttemptService {
 
             // AI 서버에 읽기용 URL 전달
             String sttText = aiServerClient.transcribe(readPresignedUrl);
-            attempt.complete(sttText);
-            log.info("STT 처리 성공 - attemptId: {}, status: COMPLETED, 텍스트 길이: {}", attemptId, sttText.length());
+            attempt.recordSttResult(sttText);
+            log.info("STT 처리 성공 - attemptId: {}, status: PROCESSING, 텍스트 길이: {}", attemptId, sttText.length());
 
             // Solo 모드 분석 시작 (Virtual Thread 백그라운드 처리)
             try {
@@ -145,14 +147,15 @@ public class AttemptService {
                 log.info("Solo 분석 백그라운드 실행 시작 - attemptId: {}", attemptId);
             } catch (Exception soloException) {
                 // Solo 분석 실패해도 STT는 성공했으므로 COMPLETED 유지
-                log.error("Solo 분석 시작 실패 (STT는 성공) - attemptId: {}", attemptId, soloException);
+                log.error("Solo 분석 시작 실패 - attemptId: {}", attemptId, soloException);
+                attempt.fail("AI_FEEDBACK_FAILED");
             }
 
         } catch (BusinessException e) {
-            // AI 서버 오류 시 FAILED 상태로 변경
-            String errorMessage = e.getMessage();
-            attempt.fail(errorMessage);
-            log.error("STT 처리 실패 - attemptId: {}, status: FAILED, error: {}", attemptId, errorMessage);
+            // STT 오류 시 FAILED 상태로 변경 (에러 코드 저장)
+            String errorCode = mapSttErrorCode(e);
+            attempt.fail(errorCode);
+            log.error("STT 처리 실패 - attemptId: {}, status: FAILED, errorCode: {}", attemptId, errorCode);
         }
 
         log.info("업로드 완료 처리 완료 - attemptId: {}, status: {}", attemptId, attempt.getStatus());
@@ -208,7 +211,7 @@ public class AttemptService {
                 yield AttemptDetailResponse.fromPending(attempt, expiresAt);
             }
             case UPLOADED -> AttemptDetailResponse.fromUploaded(attempt);
-            case PROCESSING -> AttemptDetailResponse.fromProcessing(attempt);
+            case PROCESSING -> AttemptDetailResponse.fromProcessing(attempt, resolveProcessingStep(attempt));
             case COMPLETED -> {
                 // CardFeedback 조회 (1:1 관계)
                 CardFeedback feedback = cardFeedbackRepository.findByAttemptId(attempt.getId())
@@ -265,5 +268,19 @@ public class AttemptService {
             log.error("읽기용 Presigned URL 생성 실패 - objectKey: {}", objectKey, e);
             throw new BusinessException(ErrorCode.S3_UPLOAD_ERROR);
         }
+    }
+
+    private AttemptProcessingStep resolveProcessingStep(CardAttempt attempt) {
+        return (attempt.getSttText() == null)
+            ? AttemptProcessingStep.AUDIO_ANALYSIS
+            : AttemptProcessingStep.FEEDBACK_GENERATION;
+    }
+
+    private String mapSttErrorCode(BusinessException e) {
+        return switch (e.getErrorCode()) {
+            case INVALID_AUDIO_URL -> "STT_RECOGNIZE_FAILED";
+            case AI_SERVICE_UNAVAILABLE, S3_UPLOAD_ERROR -> "STT_SERVER_ERROR";
+            default -> "UNKNOWN_ERROR";
+        };
     }
 }

--- a/src/main/java/com/imyme/mine/domain/learning/service/SoloFeedbackSaveService.java
+++ b/src/main/java/com/imyme/mine/domain/learning/service/SoloFeedbackSaveService.java
@@ -61,6 +61,9 @@ public class SoloFeedbackSaveService {
 
         feedbackRepository.save(newFeedback);
 
+        // 피드백 저장 완료 시 상태를 COMPLETED로 전환
+        attempt.complete(attempt.getSttText());
+
         log.info("Solo feedback saved - attemptId: {}, score: {}, level: {}",
             attemptId, result.overallScore(), result.level());
     }

--- a/src/main/java/com/imyme/mine/domain/learning/service/SoloService.java
+++ b/src/main/java/com/imyme/mine/domain/learning/service/SoloService.java
@@ -2,6 +2,7 @@ package com.imyme.mine.domain.learning.service;
 
 import com.imyme.mine.domain.ai.client.AiServerClient;
 import com.imyme.mine.domain.ai.dto.solo.*;
+import com.imyme.mine.domain.card.repository.CardAttemptRepository;
 import com.imyme.mine.global.error.BusinessException;
 import com.imyme.mine.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class SoloService {
 
     private final AiServerClient aiServerClient;
     private final SoloFeedbackSaveService feedbackSaveService;
+    private final CardAttemptRepository attemptRepository;
 
     private static final int MAX_RETRIES = 60;  // 최대 60회 (3분)
     private static final long POLL_INTERVAL_MS = 3000;  // 3초 간격
@@ -105,7 +107,8 @@ public class SoloService {
                 // 실패 상태 확인
                 if ("failed".equalsIgnoreCase(response.status())) {
                     log.error("Solo 분석 실패 - attemptId: {}", attemptId);
-                    throw new BusinessException(ErrorCode.AI_ANALYSIS_FAILED);
+                    markAttemptFailed(attemptId, "AI_FEEDBACK_FAILED");
+                    return;
                 }
 
                 // 아직 진행 중이면 3초 대기
@@ -114,11 +117,15 @@ public class SoloService {
             } catch (InterruptedException e) {
                 log.error("Solo 폴링 중단 - attemptId: {}", attemptId, e);
                 Thread.currentThread().interrupt();
-                throw new BusinessException(ErrorCode.AI_POLLING_TIMEOUT);
+                markAttemptFailed(attemptId, "UNKNOWN_ERROR");
+                return;
 
             } catch (BusinessException e) {
-                // BusinessException은 그대로 던짐
-                throw e;
+                if (e.getErrorCode() == ErrorCode.AI_ANALYSIS_FAILED || e.getErrorCode() == ErrorCode.AI_POLLING_TIMEOUT) {
+                    markAttemptFailed(attemptId, "AI_FEEDBACK_FAILED");
+                    return;
+                }
+                log.error("Solo 폴링 비즈니스 에러 - attemptId: {}, retry: {}", attemptId, i + 1, e);
 
             } catch (Exception e) {
                 log.error("Solo 폴링 에러 - attemptId: {}, retry: {}", attemptId, i + 1, e);
@@ -128,7 +135,14 @@ public class SoloService {
 
         // 최대 재시도 횟수 초과
         log.warn("Solo 폴링 타임아웃 (3분 초과) - attemptId: {}", attemptId);
-        throw new BusinessException(ErrorCode.AI_POLLING_TIMEOUT);
+        markAttemptFailed(attemptId, "AI_FEEDBACK_FAILED");
+    }
+
+    private void markAttemptFailed(Long attemptId, String errorCode) {
+        attemptRepository.findById(attemptId).ifPresent(attempt -> {
+            attempt.fail(errorCode);
+            log.info("Solo 분석 실패 상태 저장 - attemptId: {}, errorCode: {}", attemptId, errorCode);
+        });
     }
 
 }


### PR DESCRIPTION
### Description

  학습 시도 폴링 흐름을 문서 스펙에 맞게 조정하고, 실패 시 errorMessage에 명확한 에러 코드가 내려가도록 개선했습니다.

  ### Related Issues

  - Resolves #[75]

  ### Changes Made

  1. PROCESSING 상태에서 step(AUDIO_ANALYSIS/FEEDBACK_GENERATION)을 내려주도록 응답 구조 보강
  2. COMPLETED는 피드백 저장 완료 후에만 반환되도록 상태 전환 로직 수정
  3. 실패 시 errorMessage에 STT_... / AI_... 코드 저장 및 폴링 실패 처리 강화

  ### Screenshots or Video

  - N/A (API 응답 변경)

  ### Testing

  1. 로컬 통합 테스트 (Swagger/curl)
      - /learning/presigned-url → S3 업로드 → /upload-complete → /cards/{cardId}/attempts/{attemptId}
      - PROCESSING + step 확인 후 COMPLETED + feedback 확인
  2. STT 실패/AI 실패 시 errorMessage 코드 확인

  ### Checklist

  - [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다. (자동 테스트 미실행)
  - [ ] 관련 문서를 업데이트했습니다. (필요 시 확인)
  - [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  - DB 스키마 변경 없이 step을 추론하여 내려줍니다.
  - 기존 feedback null 폴링 흐름 대신 PROCESSING/COMPLETED 기반 폴링이 가능합니다.