### PR TITLE
🔥 Feat/solo-dto-refact

### DIFF
--- a/src/main/java/com/imyme/mine/domain/card/dto/UploadCompleteRequest.java
+++ b/src/main/java/com/imyme/mine/domain/card/dto/UploadCompleteRequest.java
@@ -1,16 +1,11 @@
 package com.imyme.mine.domain.card.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.Size;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * 오디오 업로드 완료 요청 DTO
- * - Solo 모드 분석을 위한 필드 포함
+ * - 업로드 완료 알림용 최소 필드만 수신
  */
 public record UploadCompleteRequest(
 
@@ -18,15 +13,5 @@ public record UploadCompleteRequest(
     String audioUrl,
 
     @Positive(message = "재생 시간은 양수여야 합니다.")
-    Integer durationSeconds,
-
-    @NotBlank(message = "사용자 텍스트는 필수입니다.")
-    @Size(min = 1, max = 5000, message = "텍스트는 1~5000자 사이여야 합니다.")
-    String userText,
-
-    @NotNull(message = "채점 기준(criteria)은 필수입니다.")
-    Map<String, Object> criteria,
-
-    List<Map<String, Object>> history
-
+    Integer durationSeconds
 ) {}

--- a/src/main/java/com/imyme/mine/domain/card/service/AttemptService.java
+++ b/src/main/java/com/imyme/mine/domain/card/service/AttemptService.java
@@ -14,6 +14,8 @@ import com.imyme.mine.domain.card.entity.CardFeedback;
 import com.imyme.mine.domain.card.repository.CardAttemptRepository;
 import com.imyme.mine.domain.card.repository.CardFeedbackRepository;
 import com.imyme.mine.domain.card.repository.CardRepository;
+import com.imyme.mine.domain.knowledge.entity.KnowledgeBase;
+import com.imyme.mine.domain.knowledge.repository.KnowledgeBaseRepository;
 import com.imyme.mine.domain.learning.service.SoloService;
 import com.imyme.mine.global.config.S3Properties;
 import com.imyme.mine.global.error.BusinessException;
@@ -28,6 +30,9 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -37,6 +42,7 @@ public class AttemptService {
     private final CardRepository cardRepository;
     private final CardAttemptRepository cardAttemptRepository;
     private final CardFeedbackRepository cardFeedbackRepository;
+    private final KnowledgeBaseRepository knowledgeBaseRepository;
     private final AiServerClient aiServerClient;
     private final SoloService soloService;
     private final S3Presigner s3Presigner;
@@ -138,11 +144,14 @@ public class AttemptService {
             // Solo 모드 분석 시작 (Virtual Thread 백그라운드 처리)
             try {
                 log.info("Solo 분석 시작 - attemptId: {}", attemptId);
+                String userText = sttText;
+                Map<String, Object> criteria = resolveCriteria(card);
+                List<Map<String, Object>> history = List.of();
                 soloService.startSoloAnalysisAsync(
                     attemptId,
-                    request.userText(),
-                    request.criteria(),
-                    request.history()
+                    userText,
+                    criteria,
+                    history
                 );
                 log.info("Solo 분석 백그라운드 실행 시작 - attemptId: {}", attemptId);
             } catch (Exception soloException) {
@@ -268,6 +277,22 @@ public class AttemptService {
             log.error("읽기용 Presigned URL 생성 실패 - objectKey: {}", objectKey, e);
             throw new BusinessException(ErrorCode.S3_UPLOAD_ERROR);
         }
+    }
+
+    private Map<String, Object> resolveCriteria(Card card) {
+        Map<String, Object> defaults = new HashMap<>();
+        defaults.put("maxScore", 100);
+        defaults.put("keywords", List.of(card.getKeyword().getName()));
+
+        List<String> knowledgeContents = knowledgeBaseRepository.findByKeywordId(card.getKeyword().getId())
+            .stream()
+            .filter(KnowledgeBase::getIsActive)
+            .map(KnowledgeBase::getContent)
+            .toList();
+        if (!knowledgeContents.isEmpty()) {
+            defaults.put("knowledgeBase", knowledgeContents);
+        }
+        return defaults;
     }
 
     private AttemptProcessingStep resolveProcessingStep(CardAttempt attempt) {


### PR DESCRIPTION
 ### Description

  업로드 완료 요청 DTO를 audioUrl, durationSeconds만 받도록 단순화하고, AI 요청에 필요한 userText/criteria/history는 백엔드에서 생성하도록 변경했습니다.

  ### Related Issues

  - Resolves #[77]

  ### Changes Made

  1. UploadCompleteRequest에서 userText/criteria/history 제거
  2. upload-complete 처리 시 STT 결과/DB 기반 기준값으로 AI 요청 payload 생성
  3. 프론트 요청 바디를 최소 2필드로 고정

  ### Screenshots or Video

  - N/A (API 변경)

  ### Testing

  1. POST /learning/presigned-url → 정상 응답 확인
  2. S3 PUT 업로드 완료
  3. PUT /cards/{cardId}/attempts/{attemptId}/upload-complete (audioUrl, durationSeconds만 전송)
  4. GET /cards/{cardId}/attempts/{attemptId} → COMPLETED 및 feedback 저장 확인

  ### Checklist

  - [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [ ] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  프론트는 audioUrl, durationSeconds만 전송하면 되고, AI 요청 payload는 백엔드에서 구성합니다.