### PR TITLE
feat: 로그 설정 개선 - 스택트레이스 및 MDC 키 추가

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -28,15 +28,27 @@
                 <includeMdcKeyName>path</includeMdcKeyName>
                 <includeMdcKeyName>method</includeMdcKeyName>
                 <includeMdcKeyName>status</includeMdcKeyName>
-                <includeMdcKeyName>exception</includeMdcKeyName>
+                <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>requestId</includeMdcKeyName>
+                
+                <!-- 스택트레이스 포함 -->
+                <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                    <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                    <maxLength>4096</maxLength>
+                    <shortenedClassNameLength>30</shortenedClassNameLength>
+                    <exclude>^sun\.reflect\..*\.invoke</exclude>
+                    <exclude>^net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>
+                </throwableConverter>
+                
                 <timeZone>Asia/Seoul</timeZone>
                 <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</timestampPattern>
                 <fieldNames>
                     <timestamp>timestamp</timestamp>
                     <levelValue>[ignore]</levelValue>
                     <version>[ignore]</version>
-                    <logger>[ignore]</logger>
+                    <logger>logger</logger>
                     <thread>[ignore]</thread>
+                    <stackTrace>stack_trace</stackTrace>
                 </fieldNames>
             </encoder>
         </appender>


### PR DESCRIPTION
## Summary
- userId, requestId MDC 키 추가로 사용자/요청별 로그 추적 가능
- ShortenedThrowableConverter를 통한 스택트레이스 포함
- logger, stack_trace 필드 출력 설정 추가

## Related Issue
Closes #79

## Test plan
- [ ] 로그 출력 시 userId, requestId 포함 확인
- [ ] 에러 발생 시 stack_trace 필드에 스택트레이스 출력 확인
- [ ] JSON 로그 포맷 정상 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)