### PR TITLE
[CLOUD/Feat] 로그 설정 개선 - 스택트레이스 및 MDC 키 추가

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -28,15 +28,27 @@
                 <includeMdcKeyName>path</includeMdcKeyName>
                 <includeMdcKeyName>method</includeMdcKeyName>
                 <includeMdcKeyName>status</includeMdcKeyName>
-                <includeMdcKeyName>exception</includeMdcKeyName>
+                <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>requestId</includeMdcKeyName>
+                
+                <!-- 스택트레이스 포함 -->
+                <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                    <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                    <maxLength>4096</maxLength>
+                    <shortenedClassNameLength>30</shortenedClassNameLength>
+                    <exclude>^sun\.reflect\..*\.invoke</exclude>
+                    <exclude>^net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>
+                </throwableConverter>
+                
                 <timeZone>Asia/Seoul</timeZone>
                 <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</timestampPattern>
                 <fieldNames>
                     <timestamp>timestamp</timestamp>
                     <levelValue>[ignore]</levelValue>
                     <version>[ignore]</version>
-                    <logger>[ignore]</logger>
+                    <logger>logger</logger>
                     <thread>[ignore]</thread>
+                    <stackTrace>stack_trace</stackTrace>
                 </fieldNames>
             </encoder>
         </appender>


### PR DESCRIPTION
### Description

Logback 설정을 개선하여 스택트레이스 출력 및 추가 MDC 키를 포함하도록 수정했습니다.

### Related Issues

- Resolves #81

### Changes Made

1. `exception` MDC 키를 `userId`, `requestId`로 변경
2. `ShortenedThrowableConverter`를 사용하여 스택트레이스 포함
3. `logger`, `stack_trace` 필드 출력 설정 추가

### Screenshots or Video

- N/A (설정 파일 변경)

### Testing

1. 애플리케이션 실행 후 로그 출력 확인
2. 에러 발생 시 stack_trace 필드에 스택트레이스 출력 확인
3. JSON 로그 포맷 정상 출력 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

스택트레이스는 maxDepth 30, maxLength 4096으로 제한하여 로그 크기를 관리합니다.