### PR TITLE
✨ Feat/update-attempt-count-on-feedback(#89)

### DIFF
--- a/src/main/java/com/imyme/mine/domain/card/service/CardService.java
+++ b/src/main/java/com/imyme/mine/domain/card/service/CardService.java
@@ -65,7 +65,6 @@ public class CardService {
         Card savedCard = cardRepository.save(card);
 
         user.incrementTotalCardCount();
-        user.incrementActiveCardCount();
 
         log.info("카드 생성 완료 - cardId: {}, userId: {}", savedCard.getId(), userId);
 
@@ -98,7 +97,9 @@ public class CardService {
 
         cardRepository.delete(card);
 
-        user.decrementActiveCardCount();
+        if (card.getAttemptCount() != null && card.getAttemptCount() > 0) {
+            user.decrementActiveCardCount();
+        }
 
         log.info("카드 삭제 완료 - cardId: {}, userId: {}", cardId, userId);
     }

--- a/src/main/java/com/imyme/mine/domain/learning/service/SoloFeedbackSaveService.java
+++ b/src/main/java/com/imyme/mine/domain/learning/service/SoloFeedbackSaveService.java
@@ -3,6 +3,7 @@ package com.imyme.mine.domain.learning.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.imyme.mine.domain.ai.dto.solo.SoloFeedback;
 import com.imyme.mine.domain.ai.dto.solo.SoloResult;
+import com.imyme.mine.domain.card.entity.Card;
 import com.imyme.mine.domain.card.entity.CardAttempt;
 import com.imyme.mine.domain.card.entity.CardFeedback;
 import com.imyme.mine.domain.card.repository.CardAttemptRepository;
@@ -61,8 +62,14 @@ public class SoloFeedbackSaveService {
 
         feedbackRepository.save(newFeedback);
 
-        // 피드백 저장 완료 시 상태를 COMPLETED로 전환
+        // 피드백 저장 완료 시 상태를 COMPLETED로 전환 + 카드 통계 갱신
+        Card card = attempt.getCard();
+        boolean wasGhost = card.getAttemptCount() == null || card.getAttemptCount() == 0;
         attempt.complete(attempt.getSttText());
+        card.completeAttempt(result.level().shortValue());
+        if (wasGhost) {
+            card.getUser().incrementActiveCardCount();
+        }
 
         log.info("Solo feedback saved - attemptId: {}, score: {}, level: {}",
             attemptId, result.overallScore(), result.level());


### PR DESCRIPTION
 ### Description

  피드백 저장 완료 시 카드의 attempt_count와 best_level을 갱신하고,
  ghost 카드가 프로필 카드 수에 포함되지 않도록 카운트를 조정해
  최근 학습 목록이 정상 노출되도록 수정했습니다.

  ### Related Issues

  - Resolves #89

  ### Changes Made

  1. 피드백 저장 성공 시 카드 attempt_count 및 best_level 갱신
  2. 최초 학습 완료 시에만 active_card_count 증가 처리
  3. 카드 생성/삭제 시 active_card_count 증가 조건 수정

  ### Screenshots or Video

  - N/A (백엔드 로직 변경)

  ### Testing

  1. 학습 완료 시도 생성 후 GET /cards?ghost=false에 카드 노출 확인
  2. GET /cards/{cardId}/attempts/{attemptId}에서 COMPLETED + feedback 확인
  3. 카드 삭제 시 active_card_count 감소 조건 확인

  ### Checklist

  - [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [ ] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  기존 데이터는 별도 백필(SQL) 수행 시 ghost 해제 및 카드 수 재계산이 가능합니다.

  ———