### PR TITLE
PR : Feat/presigned-url-use-attempt-id (#92)

### DIFF
--- a/src/main/java/com/imyme/mine/domain/storage/controller/StorageController.java
+++ b/src/main/java/com/imyme/mine/domain/storage/controller/StorageController.java
@@ -29,7 +29,7 @@ public class StorageController {
 
     @Operation(
         summary = "학습 오디오 Presigned URL 발급",
-        description = "학습 오디오를 S3에 직접 업로드하기 위한 서명된 URL을 발급합니다. URL 유효기간은 5분입니다.",
+        description = "학습 오디오를 S3에 직접 업로드하기 위한 서명된 URL을 발급합니다. 시도 ID를 입력받아 해당 시도에 업로드합니다.",
         security = @SecurityRequirement(name = "JWT")
     )
     @ApiResponses({
@@ -43,13 +43,23 @@ public class StorageController {
             content = @Content(schema = @Schema(ref = "#/components/schemas/ErrorResponse"))
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "403",
+            description = "접근 권한 없음 - FORBIDDEN",
+            content = @Content(schema = @Schema(ref = "#/components/schemas/ErrorResponse"))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
             responseCode = "401",
             description = "인증 실패 - UNAUTHORIZED, TOKEN_EXPIRED",
             content = @Content(schema = @Schema(ref = "#/components/schemas/ErrorResponse"))
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
             responseCode = "404",
-            description = "카드를 찾을 수 없음 - CARD_NOT_FOUND",
+            description = "시도를 찾을 수 없음 - ATTEMPT_NOT_FOUND",
+            content = @Content(schema = @Schema(ref = "#/components/schemas/ErrorResponse"))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "410",
+            description = "업로드 제한 시간 초과 - UPLOAD_EXPIRED",
             content = @Content(schema = @Schema(ref = "#/components/schemas/ErrorResponse"))
         )
     })
@@ -60,7 +70,7 @@ public class StorageController {
         @Valid @RequestBody PresignedUrlRequest request
     ) {
         Long userId = userPrincipal.getId();
-        log.info("POST /learning/presigned-url - userId: {}, cardId: {}", userId, request.cardId());
+        log.info("POST /learning/presigned-url - userId: {}, attemptId: {}", userId, request.attemptId());
 
         PresignedUrlResponse response = storageService.generatePresignedUrl(userId, request);
 

--- a/src/main/java/com/imyme/mine/domain/storage/dto/PresignedUrlRequest.java
+++ b/src/main/java/com/imyme/mine/domain/storage/dto/PresignedUrlRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.Pattern;
 
 public record PresignedUrlRequest(
 
-    @NotNull(message = "카드 ID는 필수입니다.")
-    Long cardId,
+    @NotNull(message = "시도 ID는 필수입니다.")
+    Long attemptId,
 
     @NotNull(message = "파일 확장자는 필수입니다.")
     @Pattern(regexp = "^(mp3|wav|m4a|webm)$", message = "지원하지 않는 오디오 형식입니다.")

--- a/src/main/java/com/imyme/mine/domain/storage/service/StorageService.java
+++ b/src/main/java/com/imyme/mine/domain/storage/service/StorageService.java
@@ -1,10 +1,8 @@
 package com.imyme.mine.domain.storage.service;
 
 import com.imyme.mine.domain.card.entity.AttemptStatus;
-import com.imyme.mine.domain.card.entity.Card;
 import com.imyme.mine.domain.card.entity.CardAttempt;
 import com.imyme.mine.domain.card.repository.CardAttemptRepository;
-import com.imyme.mine.domain.card.repository.CardRepository;
 import com.imyme.mine.domain.storage.dto.PresignedUrlRequest;
 import com.imyme.mine.domain.storage.dto.PresignedUrlResponse;
 import com.imyme.mine.global.config.S3Properties;
@@ -29,53 +27,46 @@ public class StorageService {
 
     private final S3Presigner s3Presigner;
     private final S3Properties s3Properties;
-    private final CardRepository cardRepository;
     private final CardAttemptRepository cardAttemptRepository;
 
-    private static final int MAX_ATTEMPTS_PER_CARD = 5;
     private static final Duration PRESIGNED_URL_EXPIRATION = Duration.ofMinutes(10);
+    private static final Duration UPLOAD_EXPIRATION = Duration.ofMinutes(10);
 
     @Transactional
     public PresignedUrlResponse generatePresignedUrl(Long userId, PresignedUrlRequest request) {
-        log.debug("Presigned URL 생성 시작 - userId: {}, cardId: {}", userId, request.cardId());
+        log.debug("Presigned URL 생성 시작 - userId: {}, attemptId: {}", userId, request.attemptId());
 
-        Card card = cardRepository.findByIdAndUserId(request.cardId(), userId)
-            .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
+        CardAttempt attempt = cardAttemptRepository.findById(request.attemptId())
+            .orElseThrow(() -> new BusinessException(ErrorCode.ATTEMPT_NOT_FOUND));
 
-        long attemptCount = cardAttemptRepository.countByCardId(card.getId());
-        if (attemptCount >= MAX_ATTEMPTS_PER_CARD) {
-            throw new BusinessException(ErrorCode.MAX_ATTEMPTS_EXCEEDED);
+        if (!attempt.getCard().getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
-        Short nextAttemptNo = calculateNextAttemptNo(card.getId());
+        if (attempt.getStatus() != AttemptStatus.PENDING) {
+            throw new BusinessException(ErrorCode.INVALID_STATUS);
+        }
 
-        CardAttempt attempt = CardAttempt.builder()
-            .card(card)
-            .attemptNo(nextAttemptNo)
-            .status(AttemptStatus.PENDING)
-            .build();
+        LocalDateTime expiresAt = attempt.getCreatedAt().plus(UPLOAD_EXPIRATION);
+        if (LocalDateTime.now().isAfter(expiresAt)) {
+            throw new BusinessException(ErrorCode.UPLOAD_EXPIRED);
+        }
 
-        CardAttempt savedAttempt = cardAttemptRepository.save(attempt);
-
-        String objectKey = generateObjectKey(userId, card.getId(), savedAttempt.getId(), request.fileExtension());
+        Long cardId = attempt.getCard().getId();
+        String objectKey = generateObjectKey(userId, cardId, attempt.getId(), request.fileExtension());
 
         PresignedPutObjectRequest presignedRequest = generatePresignedPutRequest(objectKey, request.fileExtension());
 
-        LocalDateTime expiresAt = LocalDateTime.now().plus(PRESIGNED_URL_EXPIRATION);
+        LocalDateTime presignedExpiresAt = LocalDateTime.now().plus(PRESIGNED_URL_EXPIRATION);
 
-        log.info("Presigned URL 생성 완료 - attemptId: {}, objectKey: {}", savedAttempt.getId(), objectKey);
+        log.info("Presigned URL 생성 완료 - attemptId: {}, objectKey: {}", attempt.getId(), objectKey);
 
         return PresignedUrlResponse.of(
-            savedAttempt.getId(),
+            attempt.getId(),
             presignedRequest.url().toString(),
             objectKey,
-            expiresAt
+            presignedExpiresAt
         );
-    }
-
-    private Short calculateNextAttemptNo(Long cardId) {
-        Short maxAttemptNo = cardAttemptRepository.findMaxAttemptNoByCardId(cardId);
-        return (maxAttemptNo == null) ? 1 : (short) (maxAttemptNo + 1);
     }
 
     private String generateObjectKey(Long userId, Long cardId, Long attemptId, String fileExtension) {


### PR DESCRIPTION
### Description

  presigned-url 발급 시 attempt를 새로 생성하지 않고, 기존 시도 ID(attemptId)를 받아 URL을 발급하도록 변경했습니다.
  이제 createAttempt → presigned-url → upload-complete 흐름을 명확히 지원합니다.

  ### Related Issues

  - Resolves #[92]

  ### Changes Made

  1. PresignedUrlRequest에 attemptId 추가 (cardId 제거)
  2. presigned-url 발급 시 attempt 생성 로직 제거 및 소유/상태/만료 검증 추가
  3. Swagger 설명 및 응답 코드 업데이트

  ### Screenshots or Video

  N/A (API 변경)

  ### Testing

  1. POST /cards/{cardId}/attempts → attemptId 발급
  2. POST /learning/presigned-url (attemptId, fileExtension) → URL 발급
  3. S3 PUT 업로드 → PUT /cards/{cardId}/attempts/{attemptId}/upload-complete

  ### Checklist

  - [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [ ] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  프론트는 presigned-url 요청 시 attemptId를 반드시 전달해야 합니다.