### PR TITLE
[INFRA/Feat] Prometheus 메트릭 수집을 위한 Actuator 엔드포인트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,10 @@ dependencies {
 
     // JSON 로깅 (Loki 연동)
     implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
+
+    // Prometheus 메트릭 수집
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/imyme/mine/global/config/SecurityConfig.java
+++ b/src/main/java/com/imyme/mine/global/config/SecurityConfig.java
@@ -64,7 +64,10 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
-                                "/webjars/**"
+                                "/webjars/**",
+                                "/actuator/prometheus",  // Prometheus 메트릭 수집 엔드포인트
+                                "/actuator/health",      // 헬스체크
+                                "/actuator/info"         // 애플리케이션 정보
                         ).permitAll()
                         .anyRequest().authenticated())
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -166,3 +166,24 @@ springdoc:
     show-actuator: true
     default-consumes-media-type: application/json
     default-produces-media-type: application/json
+
+# ==================================================
+# Actuator & Prometheus 설정
+# ==================================================
+management:
+    endpoints:
+        web:
+            exposure:
+                include: health,info,prometheus,metrics
+            base-path: /actuator
+    endpoint:
+        health:
+            show-details: always
+        prometheus:
+            enabled: true
+    metrics:
+        export:
+            prometheus:
+                enabled: true
+        tags:
+            application: ${spring.application.name}


### PR DESCRIPTION
### Description

Prometheus를 통한 애플리케이션 모니터링을 위해 Spring Boot Actuator를 추가하고, 메트릭 수집 엔드포인트를 설정합니다.

### Related Issues

- N/A

### Changes Made

1. **의존성 추가** (build.gradle)
   - spring-boot-starter-actuator: Spring Boot 모니터링 기능 제공
   - micrometer-registry-prometheus: Prometheus 형식 메트릭 변환

2. **Actuator 엔드포인트 설정** (application.yml)
   - /actuator/prometheus: Prometheus 메트릭 노출
   - /actuator/health: 헬스체크 (상세 정보 포함)
   - /actuator/info: 애플리케이션 정보
   - /actuator/metrics: 일반 메트릭
   - 애플리케이션 태그 설정 (application: mine)

3. **Security 설정 업데이트** (SecurityConfig.java)
   - Actuator 엔드포인트 인증 없이 접근 허용
   - Prometheus 서버가 메트릭을 수집할 수 있도록 설정

### Screenshots or Video

- N/A (인프라 설정 추가)

### Testing

1. 애플리케이션 재시작 후 다음 엔드포인트 접근 확인:
   - http://localhost:8080/actuator/prometheus
   - http://localhost:8080/actuator/health
   - http://localhost:8080/actuator/metrics
2. Prometheus 메트릭 형식 출력 확인
3. 헬스체크 응답에 데이터베이스 상태 포함 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

이 PR 이후에는 Prometheus 서버에서 다음과 같이 scrape 설정을 추가하여 메트릭을 수집할 수 있습니다:

```yaml
scrape_configs:
  - job_name: 'spring-boot-app'
    metrics_path: '/actuator/prometheus'
    static_configs:
      - targets: ['<server-host>:8080']
```

수집되는 주요 메트릭:
- JVM 메모리 사용량
- CPU 사용률
- HTTP 요청 수 및 응답 시간
- 데이터베이스 커넥션 풀 상태
- 스레드 정보