### PR TITLE
PR : Fix/attempt-count-mismatch

### DIFF
--- a/src/main/java/com/imyme/mine/domain/card/repository/CardAttemptRepository.java
+++ b/src/main/java/com/imyme/mine/domain/card/repository/CardAttemptRepository.java
@@ -22,6 +22,12 @@ public interface CardAttemptRepository extends JpaRepository<CardAttempt, Long> 
     long countByCardId(Long cardId);
 
     /**
+     * 특정 상태를 제외한 카드 시도 개수 조회
+     * - MAX_ATTEMPTS 체크 시 FAILED/EXPIRED는 제외해야 함
+     */
+    long countByCardIdAndStatusNotIn(Long cardId, List<AttemptStatus> excludedStatuses);
+
+    /**
      * 특정 상태이고 생성 시간이 특정 시간 이전인 시도 조회
      * - 스케줄러에서 만료 처리용
      */

--- a/src/main/java/com/imyme/mine/domain/card/scheduler/AttemptExpirationScheduler.java
+++ b/src/main/java/com/imyme/mine/domain/card/scheduler/AttemptExpirationScheduler.java
@@ -30,8 +30,7 @@ public class AttemptExpirationScheduler {
      * PENDING 상태 만료 처리
      * - 생성 후 10분 초과한 PENDING 시도를 EXPIRED로 전환
      */
-    // TODO: DB 제약 조건에 EXPIRED 추가 후 활성화
-    // @Scheduled(fixedRate = 60000) // 1분마다 실행
+    @Scheduled(fixedRate = 60000) // 1분마다 실행
     @Transactional
     public void expirePendingAttempts() {
         LocalDateTime expirationThreshold = LocalDateTime.now().minus(UPLOAD_EXPIRATION);

--- a/src/main/java/com/imyme/mine/domain/card/service/AttemptService.java
+++ b/src/main/java/com/imyme/mine/domain/card/service/AttemptService.java
@@ -59,7 +59,9 @@ public class AttemptService {
         Card card = cardRepository.findByIdAndUserId(cardId, userId)
             .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
 
-        long attemptCount = cardAttemptRepository.countByCardId(card.getId());
+        // FAILED/EXPIRED는 카운트에서 제외 (재시도 가능하도록)
+        List<AttemptStatus> excludedStatuses = List.of(AttemptStatus.FAILED, AttemptStatus.EXPIRED);
+        long attemptCount = cardAttemptRepository.countByCardIdAndStatusNotIn(card.getId(), excludedStatuses);
         if (attemptCount >= MAX_ATTEMPTS_PER_CARD) {
             throw new BusinessException(ErrorCode.MAX_ATTEMPTS_EXCEEDED);
         }


### PR DESCRIPTION
 ### Description

  AI 실패/만료 시도가 횟수 제한에 포함되어 “남은 횟수 표시 vs 서버 제한”이 불일치하던 문제를 해결했습니다.
  FAILED/EXPIRED를 카운트에서 제외하고, PENDING 자동 만료 스케줄러를 활성화했습니다.

  ### Related Issues

  - Resolves #[128]

  ### Changes Made

  1. AttemptService에서 시도 횟수 계산 시 FAILED/EXPIRED 상태를 제외
  2. CardAttemptRepository에 countByCardIdAndStatusNotIn 메서드 추가
  3. AttemptExpirationScheduler의 @Scheduled(fixedRate = 60000) 활성화

  ### Screenshots or Video

  - N/A (백엔드 로직 변경)

  ### Testing

  1. 로컬 빌드: ./gradlew build
  2. QA 시나리오 재검증: FAILED/EXPIRED 누적 시에도 시도 생성 가능 여부 확인

  ### Checklist

  - [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [x] 모든 테스트가 성공적으로 통과했습니다.
  - [x] 관련 문서를 업데이트했습니다.
  - [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  - 스케줄러 활성화로 PENDING 시도 자동 만료 처리됨 (1분 주기)

  ———