### PR TITLE
PR : Fix/attempt-upload-complete-tx(#135)

### DIFF
--- a/src/main/java/com/imyme/mine/domain/card/service/AttemptService.java
+++ b/src/main/java/com/imyme/mine/domain/card/service/AttemptService.java
@@ -51,6 +51,7 @@ public class AttemptService {
     private final S3Presigner s3Presigner;
     private final S3Properties s3Properties;
     private final AttemptProperties attemptProperties;
+    private final AttemptUploadService attemptUploadService;
 
     private static final int MAX_ATTEMPTS_PER_CARD = 5;
 
@@ -98,8 +99,8 @@ public class AttemptService {
     public UploadCompleteResponse uploadComplete(Long userId, Long cardId, Long attemptId, UploadCompleteRequest request) {
         log.debug("업로드 완료 처리 시작 - userId: {}, cardId: {}, attemptId: {}", userId, cardId, attemptId);
 
-        // 1단계: 트랜잭션 내에서 검증 및 상태 업데이트만 수행
-        ValidatedAttempt validated = markAttemptAsUploaded(userId, cardId, attemptId, request);
+        // 1단계: 트랜잭션 내에서 검증 및 상태 업데이트만 수행 (프록시 호출로 @Transactional 보장)
+        ValidatedAttempt validated = attemptUploadService.markAttemptAsUploaded(userId, cardId, attemptId, request);
         Card card = validated.card();
 
         // 2단계: 트랜잭션 외부에서 외부 HTTP 호출 수행
@@ -112,36 +113,6 @@ public class AttemptService {
         log.info("업로드 완료 처리 완료 - attemptId: {}, status: {}", attemptId, finalAttempt.getStatus());
 
         return UploadCompleteResponse.from(finalAttempt);
-    }
-
-    /**
-     * 1단계: 트랜잭션 내에서 검증 및 상태 업데이트
-     * - DB 커넥션을 빠르게 반환하기 위해 외부 HTTP 호출 전에 트랜잭션 종료
-     */
-    @Transactional
-    protected ValidatedAttempt markAttemptAsUploaded(Long userId, Long cardId, Long attemptId, UploadCompleteRequest request) {
-        ValidatedAttempt validated = validateAttemptOwnership(userId, cardId, attemptId);
-        CardAttempt attempt = validated.attempt();
-
-        if (attempt.getStatus() != AttemptStatus.PENDING) {
-            throw new BusinessException(ErrorCode.INVALID_STATUS);
-        }
-
-        LocalDateTime expiresAt = attempt.getCreatedAt().plus(Duration.ofMinutes(attemptProperties.getUploadExpirationMinutes()));
-        if (LocalDateTime.now().isAfter(expiresAt)) {
-            throw new BusinessException(ErrorCode.UPLOAD_EXPIRED);
-        }
-
-        if (!request.objectKey().equals(attempt.getAudioKey())) {
-            throw new BusinessException(ErrorCode.INVALID_OBJECT_KEY);
-        }
-
-        attempt.markUploaded(request.durationSeconds());
-        attempt.startProcessing();
-
-        log.info("시도 업로드 상태로 변경 완료 - attemptId: {}, status: {}", attemptId, attempt.getStatus());
-
-        return validated;
     }
 
     /**

--- a/src/main/java/com/imyme/mine/domain/card/service/AttemptUploadService.java
+++ b/src/main/java/com/imyme/mine/domain/card/service/AttemptUploadService.java
@@ -1,0 +1,66 @@
+package com.imyme.mine.domain.card.service;
+
+import com.imyme.mine.domain.card.dto.UploadCompleteRequest;
+import com.imyme.mine.domain.card.dto.ValidatedAttempt;
+import com.imyme.mine.domain.card.entity.AttemptStatus;
+import com.imyme.mine.domain.card.entity.Card;
+import com.imyme.mine.domain.card.entity.CardAttempt;
+import com.imyme.mine.domain.card.repository.CardAttemptRepository;
+import com.imyme.mine.domain.card.repository.CardRepository;
+import com.imyme.mine.global.config.AttemptProperties;
+import com.imyme.mine.global.error.BusinessException;
+import com.imyme.mine.global.error.ErrorCode;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AttemptUploadService {
+
+    private final CardRepository cardRepository;
+    private final CardAttemptRepository cardAttemptRepository;
+    private final AttemptProperties attemptProperties;
+
+    /**
+     * 업로드 완료 처리 1단계: 트랜잭션 내에서 검증 및 상태 업데이트
+     * - 외부 HTTP 호출 전에 트랜잭션 종료
+     */
+    @Transactional
+    public ValidatedAttempt markAttemptAsUploaded(Long userId, Long cardId, Long attemptId, UploadCompleteRequest request) {
+        Card card = cardRepository.findByIdAndUserId(cardId, userId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
+
+        CardAttempt attempt = cardAttemptRepository.findById(attemptId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.ATTEMPT_NOT_FOUND));
+
+        if (!attempt.getCard().getId().equals(card.getId())) {
+            throw new BusinessException(ErrorCode.INVALID_CARD_ATTEMPT_MISMATCH);
+        }
+
+        if (attempt.getStatus() != AttemptStatus.PENDING) {
+            throw new BusinessException(ErrorCode.INVALID_STATUS);
+        }
+
+        LocalDateTime expiresAt = attempt.getCreatedAt()
+            .plus(Duration.ofMinutes(attemptProperties.getUploadExpirationMinutes()));
+        if (LocalDateTime.now().isAfter(expiresAt)) {
+            throw new BusinessException(ErrorCode.UPLOAD_EXPIRED);
+        }
+
+        if (!request.objectKey().equals(attempt.getAudioKey())) {
+            throw new BusinessException(ErrorCode.INVALID_OBJECT_KEY);
+        }
+
+        attempt.markUploaded(request.durationSeconds());
+        attempt.startProcessing();
+
+        log.info("시도 업로드 상태로 변경 완료 - attemptId: {}, status: {}", attemptId, attempt.getStatus());
+
+        return new ValidatedAttempt(card, attempt);
+    }
+}


### PR DESCRIPTION
fix transaction: pending 상태 지속 문제 수정

  ### Description

  upload-complete 호출 후에도 시도 상태가 PENDING에 머무르던 문제를 수정했습니다.
  원인은 동일 클래스 내부 @Transactional 메서드 호출로 트랜잭션이 적용되지 않던 구조였고, 이를 별도 서비스로 분리해 해결했습니다.

  ### Related Issues

  - Resolves #<135>

  ### Changes Made

  1. AttemptUploadService 추가 및 markAttemptAsUploaded() 이동 (@Transactional 보장)
  2. AttemptService.uploadComplete()에서 새 서비스 호출로 변경
  3. 상태 업데이트 로직을 트랜잭션 영역에 고정하여 PENDING → PROCESSING 전환 보장

  ### Screenshots or Video

  - (없음)

  ### Testing

  1. ./gradlew test

  ### Checklist

  - [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [x] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  - 기존 upload-complete 흐름은 유지하면서 트랜잭션 적용만 분리했습니다.