### PR TITLE
PR:  Fix/solo-lazyinit-polling(#137)

### DIFF
--- a/src/main/java/com/imyme/mine/domain/card/repository/CardAttemptRepository.java
+++ b/src/main/java/com/imyme/mine/domain/card/repository/CardAttemptRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CardAttemptRepository extends JpaRepository<CardAttempt, Long> {
@@ -32,4 +33,17 @@ public interface CardAttemptRepository extends JpaRepository<CardAttempt, Long> 
      * - 스케줄러에서 만료 처리용
      */
     List<CardAttempt> findByStatusAndCreatedAtBefore(AttemptStatus status, LocalDateTime createdAt);
+
+    /**
+     * CardAttempt를 Card 및 User와 함께 조회 (Lazy Loading 방지)
+     * - SoloFeedbackSaveService에서 사용
+     * - Virtual Thread에서 실행되므로 fetch join 필수
+     */
+    @Query("""
+        SELECT ca FROM CardAttempt ca
+        JOIN FETCH ca.card c
+        JOIN FETCH c.user
+        WHERE ca.id = :attemptId
+        """)
+    Optional<CardAttempt> findByIdWithCardAndUser(@Param("attemptId") Long attemptId);
 }

--- a/src/main/java/com/imyme/mine/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/imyme/mine/domain/card/repository/CardRepository.java
@@ -18,6 +18,19 @@ public interface CardRepository extends JpaRepository<Card, Long> {
 
     @Query("""
         SELECT c FROM Card c
+        JOIN FETCH c.keyword
+        JOIN FETCH c.user
+        WHERE c.id = :cardId
+        AND c.user.id = :userId
+        AND c.deletedAt IS NULL
+        """)
+    Optional<Card> findByIdAndUserIdWithKeyword(
+        @Param("cardId") Long cardId,
+        @Param("userId") Long userId
+    );
+
+    @Query("""
+        SELECT c FROM Card c
         JOIN FETCH c.category
         JOIN FETCH c.keyword
         WHERE c.user.id = :userId

--- a/src/main/java/com/imyme/mine/domain/card/service/AttemptService.java
+++ b/src/main/java/com/imyme/mine/domain/card/service/AttemptService.java
@@ -52,6 +52,7 @@ public class AttemptService {
     private final S3Properties s3Properties;
     private final AttemptProperties attemptProperties;
     private final AttemptUploadService attemptUploadService;
+    private final AttemptSttService attemptSttService;
 
     private static final int MAX_ATTEMPTS_PER_CARD = 5;
 
@@ -132,8 +133,7 @@ public class AttemptService {
             String sttText = aiServerClient.transcribe(readPresignedUrl);
 
             // STT 결과 저장 (새 트랜잭션)
-            recordSttSuccess(attemptId, sttText);
-            log.info("STT 처리 성공 - attemptId: {}, 텍스트 길이: {}", attemptId, sttText.length());
+            attemptSttService.recordSttSuccess(attemptId, sttText);
 
             // Solo 모드 분석 이벤트 발행 (비동기 처리)
             publishSoloAnalysisEvent(attemptId, card, sttText);
@@ -141,33 +141,13 @@ public class AttemptService {
         } catch (BusinessException e) {
             // STT 오류 시 FAILED 상태로 변경 (새 트랜잭션)
             String errorCode = mapSttErrorCode(e);
-            recordSttFailure(attemptId, errorCode);
+            attemptSttService.recordSttFailure(attemptId, errorCode);
             log.error("STT 처리 실패 - attemptId: {}, errorCode: {}", attemptId, errorCode);
         } catch (Exception e) {
             // 예상치 못한 오류
-            recordSttFailure(attemptId, "UNKNOWN_ERROR");
+            attemptSttService.recordSttFailure(attemptId, "UNKNOWN_ERROR");
             log.error("STT 처리 중 예상치 못한 오류 - attemptId: {}", attemptId, e);
         }
-    }
-
-    /**
-     * STT 성공 결과 저장 (새 트랜잭션)
-     */
-    @Transactional
-    protected void recordSttSuccess(Long attemptId, String sttText) {
-        CardAttempt attempt = cardAttemptRepository.findById(attemptId)
-            .orElseThrow(() -> new BusinessException(ErrorCode.ATTEMPT_NOT_FOUND));
-        attempt.recordSttResult(sttText);
-    }
-
-    /**
-     * STT 실패 기록 (새 트랜잭션)
-     */
-    @Transactional
-    protected void recordSttFailure(Long attemptId, String errorCode) {
-        CardAttempt attempt = cardAttemptRepository.findById(attemptId)
-            .orElseThrow(() -> new BusinessException(ErrorCode.ATTEMPT_NOT_FOUND));
-        attempt.fail(errorCode);
     }
 
     /**
@@ -195,7 +175,7 @@ public class AttemptService {
         } catch (Exception e) {
             // 이벤트 발행 실패해도 STT는 성공했으므로 계속 진행
             log.error("Solo 분석 이벤트 발행 실패 - attemptId: {}", attemptId, e);
-            recordSttFailure(attemptId, "AI_FEEDBACK_FAILED");
+            attemptSttService.recordSttFailure(attemptId, "AI_FEEDBACK_FAILED");
         }
     }
 

--- a/src/main/java/com/imyme/mine/domain/card/service/AttemptSttService.java
+++ b/src/main/java/com/imyme/mine/domain/card/service/AttemptSttService.java
@@ -1,0 +1,34 @@
+package com.imyme.mine.domain.card.service;
+
+import com.imyme.mine.domain.card.entity.CardAttempt;
+import com.imyme.mine.domain.card.repository.CardAttemptRepository;
+import com.imyme.mine.global.error.BusinessException;
+import com.imyme.mine.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AttemptSttService {
+
+    private final CardAttemptRepository cardAttemptRepository;
+
+    @Transactional
+    public void recordSttSuccess(Long attemptId, String sttText) {
+        CardAttempt attempt = cardAttemptRepository.findById(attemptId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.ATTEMPT_NOT_FOUND));
+        attempt.recordSttResult(sttText);
+        log.info("STT 처리 성공 - attemptId: {}, 텍스트 길이: {}", attemptId, sttText.length());
+    }
+
+    @Transactional
+    public void recordSttFailure(Long attemptId, String errorCode) {
+        CardAttempt attempt = cardAttemptRepository.findById(attemptId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.ATTEMPT_NOT_FOUND));
+        attempt.fail(errorCode);
+        log.info("STT 처리 실패 상태 저장 - attemptId: {}, errorCode: {}", attemptId, errorCode);
+    }
+}

--- a/src/main/java/com/imyme/mine/domain/card/service/AttemptUploadService.java
+++ b/src/main/java/com/imyme/mine/domain/card/service/AttemptUploadService.java
@@ -32,7 +32,7 @@ public class AttemptUploadService {
      */
     @Transactional
     public ValidatedAttempt markAttemptAsUploaded(Long userId, Long cardId, Long attemptId, UploadCompleteRequest request) {
-        Card card = cardRepository.findByIdAndUserId(cardId, userId)
+        Card card = cardRepository.findByIdAndUserIdWithKeyword(cardId, userId)
             .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
 
         CardAttempt attempt = cardAttemptRepository.findById(attemptId)

--- a/src/main/java/com/imyme/mine/domain/learning/service/SoloFeedbackSaveService.java
+++ b/src/main/java/com/imyme/mine/domain/learning/service/SoloFeedbackSaveService.java
@@ -23,7 +23,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class SoloFeedbackSaveService {
 
-    private static final String SOLO_MODEL_VERSION = "solo-v1";
+    private static final String SOLO_MODEL_VERSION = "gemini-3-pro-preview";
 
     private final CardAttemptRepository attemptRepository;
     private final CardFeedbackRepository feedbackRepository;
@@ -45,8 +45,9 @@ public class SoloFeedbackSaveService {
             return;
         }
 
-        // CardAttempt 조회 (존재 확인 + @MapsId 연관관계 설정용)
-        CardAttempt attempt = attemptRepository.findById(attemptId)
+        // CardAttempt 조회 (Card 및 User와 함께 fetch join)
+        // Virtual Thread에서 실행되므로 lazy loading 방지 필수
+        CardAttempt attempt = attemptRepository.findByIdWithCardAndUser(attemptId)
             .orElseThrow(() -> new BusinessException(ErrorCode.ATTEMPT_NOT_FOUND));
 
         String feedbackJson = convertSoloFeedbackToJson(result.feedback());


### PR DESCRIPTION
🐛 Fix: LazyInitializationException in Solo analysis event

## Description
Solo 분석 이벤트 발행 시 `LazyInitializationException`이 발생하여 사용자의 학습 시도가 `AUDIO_ANALYSIS` 상태에서 멈추는 문제를 해결했습니다.

## Problem
- 업로드 완료 후 Solo 분석 이벤트 발행 시 에러 발생
- `card.getUser().getId()` 및 `card.getKeyword().getName()` 접근 시 `LazyInitializationException`
- 결과적으로 사용자의 시도가 `PROCESSING` 상태에서 진행되지 않음

## Related Issues
- Resolves: [BE/Fix] 개발서버 Transactional 보장 #137

## Changes Made

### 1) CardRepository - user fetch join 추가
**Before**
```java
JOIN FETCH c.keyword
````

**After**

```java
JOIN FETCH c.keyword
JOIN FETCH c.user // ← 추가
```

* `findByIdAndUserIdWithKeyword()` 메서드에 `user fetch join` 추가
* 트랜잭션 외부에서 `card.getUser()` 접근 가능하도록 수정

### 2) CardAttemptRepository - fetch join 메서드 추가 (Virtual Thread 대응)

```java
@Query("""
SELECT ca FROM CardAttempt ca
JOIN FETCH ca.card c
JOIN FETCH c.user
WHERE ca.id = :attemptId
""")
Optional<CardAttempt> findByIdWithCardAndUser(@Param("attemptId") Long attemptId);
```

* Virtual Thread에서 실행되는 `SoloFeedbackSaveService`를 위해 추가
* Card + User를 함께 로딩하여 lazy loading 방지

### 3) SoloFeedbackSaveService - fetch join 메서드 사용

**Before**

```java
CardAttempt attempt = attemptRepository.findById(attemptId);
```

**After**

```java
CardAttempt attempt = attemptRepository.findByIdWithCardAndUser(attemptId);
```

* Virtual Thread 환경에서 세션 없이도 `Card`와 `User` 접근 가능

### 4) AttemptSttService 분리 (self-invocation 해결)

```java
@Service
public class AttemptSttService {

  @Transactional
  public void recordSttSuccess(Long attemptId, String sttText) { ... }

  @Transactional
  public void recordSttFailure(Long attemptId, String errorCode) { ... }
}
```

* `AttemptService` 내부의 self-invocation 문제 해결
* 별도 서비스로 분리하여 Spring AOP 프록시를 통한 `@Transactional` 적용 보장

## Root Cause Analysis

### Issue 1) publishSoloAnalysisEvent() LazyInitializationException

```java
private void publishSoloAnalysisEvent(Long attemptId, Card card, ...) {
  // card는 이미 detached 상태 (트랜잭션 종료됨)
  Map<String, Object> criteria = resolveCriteria(card);

  card.getKeyword().getName(); // 💥 LazyInitializationException
  card.getUser().getId();      // 💥 LazyInitializationException
}
```

* 원인: `markAttemptAsUploaded()` 트랜잭션 종료 후 `processAfterUpload()`에서 detached된 `Card` 엔티티 사용

### Issue 2) SoloFeedbackSaveService LazyInitializationException (Virtual Thread)

```java
@Transactional
public void save(Long attemptId, SoloResult result) {
  CardAttempt attempt = attemptRepository.findById(attemptId);
  Card card = attempt.getCard(); // 💥 lazy loading
  card.getUser().incrementActiveCardCount(); // 💥 lazy loading
}
```

* 원인: Virtual Thread 환경에서 세션 없이 lazy loading 시도

### Issue 3) Self-invocation

```java
// AttemptService 내부
private void processAfterUpload(...) {
  recordSttSuccess(...); // ← self-invocation, @Transactional 미적용
}
```

* 원인: Spring AOP 프록시를 거치지 않는 내부 메서드 호출

## Testing

### Environment

* Local: macOS, PostgreSQL 17, Java 21
* 전체 플로우 테스트: 오디오 업로드 → STT → Solo 분석 → 피드백 생성

### Result

* ✅ 시도 생성 성공
* ✅ S3 업로드 성공 (스레드.wav, 1.5MB)
* ✅ 업로드 완료 API 성공
* ✅ STT 처리 성공 (텍스트 216자 추출)
* ✅ Solo 분석 이벤트 발행 완료 (LazyInitializationException 없음)
* ✅ Solo 분석 요청 성공
* ✅ 피드백 생성 완료 (level: 1, score: 0)
* ✅ 최종 상태: COMPLETED
* ✅ 총 소요 시간: 38초

### Logs

```text
2026-02-09 16:50:25.561 [ INFO] STT 처리 성공 - attemptId: 12, 텍스트 길이: 216
2026-02-09 16:50:25.565 [ INFO] Solo 분석 이벤트 발행 - attemptId: 12
2026-02-09 16:50:25.588 [ INFO] Solo 분석 이벤트 발행 완료 - attemptId: 12 ✨
2026-02-09 16:50:25.588 [ INFO] AttemptUploadedEvent 수신 - attemptId: 12
2026-02-09 16:50:34.908 [ INFO] Solo feedback saved - attemptId: 12
```

## Before / After

### Before (Dev 서버)

```text
ERROR - Solo 분석 이벤트 발행 실패 - attemptId: 18
org.hibernate.LazyInitializationException: Could not initialize proxy [Keyword#45] - no session
```

* Status: `AUDIO_ANALYSIS` (멈춤)

### After (Fix)

```text
INFO - Solo 분석 이벤트 발행 완료 - attemptId: 12
INFO - AttemptUploadedEvent 수신 - attemptId: 12
INFO - Solo feedback saved - attemptId: 12
```

* Status: `COMPLETED` ✅

## Checklist

* [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
* [x] 모든 테스트가 성공적으로 통과했습니다.
* [x] 관련 문서를 업데이트했습니다. (CLAUDE.md 참조)
* [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
* [x] 코드 스타일 가이드라인을 준수했습니다.
* [x] 코드 리뷰어를 지정했습니다.

## Additional Notes

이번 수정을 통해 다음 패턴을 확립했습니다.

* **Fetch Join 활용**: 트랜잭션 외부로 엔티티를 전달할 때는 필요한 연관 엔티티를 즉시 로딩
* **Virtual Thread 대응**: 별도 세션을 가지지 않는 Virtual Thread에서는 fetch join 필수
* **Self-invocation 회피**: `@Transactional` 메서드는 별도 서비스로 분리하여 AOP 프록시 보장

````

---

## ✅ “적용 안 됨”을 즉시 해결하는 체크

PR 본문에 붙여넣을 때 아래만 확인하시면 됩니다.

- 맨 위/중간에 **불필요한 4칸 들여쓰기**가 섞여 있으면 → 전체가 코드블록처럼 보입니다. (특히 Notion/Slack에서 복붙하면 자주 생김)
- 코드 조각은 반드시 **```java** … **```** 로 감싸기
- 헤더는 반드시 `##` / `###` 사용 (그냥 “Description”만 쓰면 헤더가 아닙니다)

원하시면, 지금 “적용이 안 되는 원본 PR 텍스트”를 그대로 붙여주시면(있는 그대로), 제가 **어느 줄에서 코드블록으로 깨지는지 정확히 지점 표시**해서 더 확실하게 잡아드릴게요.
````
