### PR TITLE
feat/infra[#193]: HTTP 요청 histogram 메트릭 활성화

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -155,5 +155,8 @@ management:
         export:
             prometheus:
                 enabled: true
+        distribution:
+            percentiles-histogram:
+                http.server.requests: true
         tags:
             application: ${spring.application.name}


### PR DESCRIPTION
🔗 관련 이슈
#193

❗️ 필요성
Grafana에서 HTTP 요청의 응답 시간 percentile(p50, p90, p95, p99)을 계산하려면 Prometheus histogram bucket 메트릭이 필요함

📄 내용
`management.metrics.distribution.percentiles-histogram.http.server.requests: true` 설정 추가

⬅️ 변경전
histogram bucket 메트릭 미노출 → percentile 계산 불가

✅ 변경 후
`http_server_requests_seconds_bucket` 메트릭 노출 → `histogram_quantile()` 함수로 percentile 계산 가능

💁 결론
Grafana에서 API 응답 시간 분포 모니터링 가능 (p50, p90, p95, p99)