### PR TITLE
PR :  Fix/pvp-feedback-request-users

### DIFF
--- a/src/main/java/com/imyme/mine/domain/pvp/service/PvpMqConsumerService.java
+++ b/src/main/java/com/imyme/mine/domain/pvp/service/PvpMqConsumerService.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -151,15 +152,15 @@ public class PvpMqConsumerService {
             return; // 아직 대기 중
         }
 
-        // Feedback Request 생성
+        // Feedback Request 생성 (항상 2명 포함)
         String keywordName = room.getKeyword() != null ? room.getKeyword().getName() : "";
+        List<FeedbackRequestDto.UserAnswer> userAnswers = buildUserAnswers(room, submissions);
 
-        List<FeedbackRequestDto.UserAnswer> userAnswers = completedStt.stream()
-                .map(s -> FeedbackRequestDto.UserAnswer.builder()
-                        .userId(s.getUser().getId())
-                        .userText(s.getSttText())
-                        .build())
-                .toList();
+        if (userAnswers.size() != 2) {
+            log.warn("[MQ] Feedback Request 스킵: users size != 2 - roomId={}, size={}",
+                    roomId, userAnswers.size());
+            return;
+        }
 
         FeedbackRequestDto feedbackRequest = FeedbackRequestDto.builder()
                 .roomId(roomId)
@@ -399,6 +400,38 @@ public class PvpMqConsumerService {
                 messagePublisher.publish(PvpChannels.getRoomChannel(roomId), message);
             }
         });
+    }
+
+    /**
+     * Feedback Request용 users 배열 생성 (항상 2명)
+     * - PROCESSING: sttText 사용
+     * - FAILED 또는 없음: user_text = ""
+     */
+    private List<FeedbackRequestDto.UserAnswer> buildUserAnswers(PvpRoom room, List<PvpSubmission> submissions) {
+        User host = room.getHostUser();
+        User guest = room.getGuestUser();
+
+        if (host == null || guest == null) {
+            log.warn("[MQ] Feedback Request 생성 실패: host/guest null - roomId={}", room.getId());
+            return List.of();
+        }
+
+        Map<Long, PvpSubmission> submissionMap = submissions.stream()
+                .collect(Collectors.toMap(s -> s.getUser().getId(), s -> s));
+
+        return List.of(host, guest).stream()
+                .map(user -> {
+                    PvpSubmission s = submissionMap.get(user.getId());
+                    String text = "";
+                    if (s != null && s.getStatus() == PvpSubmissionStatus.PROCESSING) {
+                        text = s.getSttText() != null ? s.getSttText() : "";
+                    }
+                    return FeedbackRequestDto.UserAnswer.builder()
+                            .userId(user.getId())
+                            .userText(text)
+                            .build();
+                })
+                .toList();
     }
 
     private String nullSafe(String value) {


### PR DESCRIPTION
 ### Description                                                                                                                                                             
                                  
  PvP Feedback Request 발행 시 AI 서버 MQ 스펙에 맞게 users 배열에 항상 2명을 포함하도록 변경합니다.                                                                          
  기존에는 STT 성공(PROCESSING) 유저만 포함했으나, FAIL 유저도 `user_text: ""`로 포함하여 AI 서버가 항상 2명의 데이터를 받을 수 있도록 보장합니다.
                                                                                                                                                                              
  ### Related Issues                                 

  - Resolves #196

  ### Changes Made

  1. `buildUserAnswers()` 메서드 추가: host/guest 기준으로 users 배열 생성. PROCESSING 유저는 sttText, FAILED 유저는 `user_text = ""`로 발행
  2. host/guest null 방어 코드: host 또는 guest가 null이면 빈 리스트 반환 + warn 로그
  3. `userAnswers.size() != 2` 발행 차단: 2명이 아니면 Feedback Request 발행 스킵하여 잘못된 payload가 MQ에 나가는 것을 방지

  ### Screenshots or Video

  N/A (백엔드 로직 변경)

  ### Testing

  1. 양쪽 STT SUCCESS: Feedback Request payload에 users 2명 포함 확인
  2. 한쪽 STT FAIL: FAIL 유저도 `user_text: ""`로 users에 포함, 총 2명 확인
  3. 빌드 검증: `./gradlew compileJava` 성공

  ### Checklist

  - [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [x] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  - 변경 파일: `PvpMqConsumerService.java` 1개
  - 발행 조건(bothDone, oneCompleteOneFail)과 feedbackRequestedAt 중복 발행 방지 로직은 기존 그대로 유지