### PR TITLE
PR : Feat : 소켓 테스트용 유저 생성 api 구현

### DIFF
--- a/src/main/java/com/imyme/mine/domain/auth/controller/E2EAuthController.java
+++ b/src/main/java/com/imyme/mine/domain/auth/controller/E2EAuthController.java
@@ -34,6 +34,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class E2EAuthController {
 
     private static final String E2E_TEST_USER_OAUTH_ID = "e2e_test_user";
+    private static final String E2E_SOCKET_HOST_OAUTH_ID = "e2e_socket_host";
+    private static final String E2E_SOCKET_GUEST_OAUTH_ID = "e2e_socket_guest";
 
     private final UserRepository userRepository;
     private final OAuthService oauthService;
@@ -99,5 +101,61 @@ public class E2EAuthController {
         log.info("E2E test login successful: userId={}, deviceUuid={}", testUser.getId(), request.deviceUuid());
 
         return ApiResponse.success(response, "E2E 테스트 로그인 성공");
+    }
+
+    /**
+     * E2E 소켓 테스트 HOST 로그인
+     * - PvP 소켓 테스트에서 방을 생성하는 호스트 역할
+     */
+    @PostMapping("/login/host")
+    @Transactional
+    public ApiResponse<OAuthLoginResponse> e2eHostLogin(@Valid @RequestBody E2ELoginRequest request) {
+        log.info("E2E socket host login attempt: deviceUuid={}", request.deviceUuid());
+
+        User hostUser = userRepository
+            .findByOauthIdAndOauthProvider(E2E_SOCKET_HOST_OAUTH_ID, OAuthProviderType.E2E_TEST)
+            .orElseGet(() -> {
+                User newUser = User.builder()
+                    .oauthId(E2E_SOCKET_HOST_OAUTH_ID)
+                    .oauthProvider(OAuthProviderType.E2E_TEST)
+                    .nickname("E2E호스트")
+                    .build();
+                userRepository.save(newUser);
+                log.info("E2E socket host auto-created: userId={}", newUser.getId());
+                return newUser;
+            });
+
+        OAuthLoginResponse response = oauthService.login(hostUser, request.deviceUuid(), false);
+        log.info("E2E socket host login successful: userId={}", hostUser.getId());
+
+        return ApiResponse.success(response, "E2E 소켓 호스트 로그인 성공");
+    }
+
+    /**
+     * E2E 소켓 테스트 GUEST 로그인
+     * - PvP 소켓 테스트에서 방에 입장하는 게스트 역할
+     */
+    @PostMapping("/login/guest")
+    @Transactional
+    public ApiResponse<OAuthLoginResponse> e2eGuestLogin(@Valid @RequestBody E2ELoginRequest request) {
+        log.info("E2E socket guest login attempt: deviceUuid={}", request.deviceUuid());
+
+        User guestUser = userRepository
+            .findByOauthIdAndOauthProvider(E2E_SOCKET_GUEST_OAUTH_ID, OAuthProviderType.E2E_TEST)
+            .orElseGet(() -> {
+                User newUser = User.builder()
+                    .oauthId(E2E_SOCKET_GUEST_OAUTH_ID)
+                    .oauthProvider(OAuthProviderType.E2E_TEST)
+                    .nickname("E2E게스트")
+                    .build();
+                userRepository.save(newUser);
+                log.info("E2E socket guest auto-created: userId={}", newUser.getId());
+                return newUser;
+            });
+
+        OAuthLoginResponse response = oauthService.login(guestUser, request.deviceUuid(), false);
+        log.info("E2E socket guest login successful: userId={}", guestUser.getId());
+
+        return ApiResponse.success(response, "E2E 소켓 게스트 로그인 성공");
     }
 }

--- a/src/main/resources/db/testdata/R__add_e2e_test_user.sql
+++ b/src/main/resources/db/testdata/R__add_e2e_test_user.sql
@@ -48,3 +48,71 @@ INSERT INTO users (
     CURRENT_TIMESTAMP
 )
 ON CONFLICT (oauth_id, oauth_provider) DO NOTHING;
+
+-- E2E 소켓 테스트용 HOST 유저
+INSERT INTO users (
+    oauth_id,
+    oauth_provider,
+    email,
+    nickname,
+    profile_image_url,
+    role,
+    level,
+    total_card_count,
+    active_card_count,
+    consecutive_days,
+    win_count,
+    last_login_at,
+    created_at,
+    updated_at
+) VALUES (
+    'e2e_socket_host',
+    'E2E_TEST',
+    'e2e_host@test.com',
+    'E2E호스트',
+    NULL,
+    'USER',
+    1,
+    0,
+    0,
+    1,
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+)
+ON CONFLICT (oauth_id, oauth_provider) DO NOTHING;
+
+-- E2E 소켓 테스트용 GUEST 유저
+INSERT INTO users (
+    oauth_id,
+    oauth_provider,
+    email,
+    nickname,
+    profile_image_url,
+    role,
+    level,
+    total_card_count,
+    active_card_count,
+    consecutive_days,
+    win_count,
+    last_login_at,
+    created_at,
+    updated_at
+) VALUES (
+    'e2e_socket_guest',
+    'E2E_TEST',
+    'e2e_guest@test.com',
+    'E2E게스트',
+    NULL,
+    'USER',
+    1,
+    0,
+    0,
+    1,
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+)
+ON CONFLICT (oauth_id, oauth_provider) DO NOTHING;


### PR DESCRIPTION
### Description                                              
   
  E2E 소켓 테스트를 위한 고정 테스트 유저(host, guest)와 각각의
   액세스 토큰을 발급받을 수 있는 엔드포인트를 추가합니다.

  기존 `/e2e/login`은 단일 유저만 지원해 PvP 소켓 테스트 시 두
  개의 독립 세션을 구성하기 어려웠습니다. host/guest 역할을
  고정한 유저와 전용 로그인 엔드포인트를 제공해 소켓 테스트
  사전 준비를 단순화합니다.

  ### Related Issues

  - Resolves #[이슈 번호]

  ### Changes Made

  1. **E2E 소켓 테스트용 유저 DB 추가**
  (`R__add_e2e_test_user.sql`)
     - `e2e_socket_host` / `E2E호스트` 유저 추가 (방 생성 역할)
     - `e2e_socket_guest` / `E2E게스트` 유저 추가 (방 입장
  역할)
     - Repeatable Migration(`R__`) 사용, `ON CONFLICT DO
  NOTHING`으로 멱등성 보장

  2. **E2E 소켓 로그인 엔드포인트 추가**
  (`E2EAuthController.java`)
     - `POST /e2e/login/host` — 호스트 액세스 토큰 발급
     - `POST /e2e/login/guest` — 게스트 액세스 토큰 발급
     - `@Profile("!prod")` 유지, 운영 환경 비활성화
     - 유저 미존재 시 자동 생성 (기존 `/e2e/login` 패턴 동일)
     - Request Body: `{ "deviceUuid": "소문자 UUID" }`
  (host/guest 반드시 다른 UUID 사용)

  ### Screenshots or Video

  N/A (백엔드 API 변경)

  ### Testing

  1. `POST /e2e/login/host { "deviceUuid":
  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" }` 호출 → accessToken
  정상 반환 확인
  2. `POST /e2e/login/guest { "deviceUuid":
  "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" }` 호출 → accessToken
  정상 반환 확인
  3. 두 토큰으로 동시에 WebSocket 연결 후 PvP 소켓 플로우 정상
  동작 확인
  4. `deviceUuid` 대문자 입력 시 400 에러 반환 확인

  ### Checklist

  - [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [x] 모든 테스트가 성공적으로 통과했습니다.
  - [x] 관련 문서를 업데이트했습니다. (`docs/E2E_TEST_API.md`)
  - [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  - `deviceUuid`는 소문자 16진수 UUID 형식만 허용
  (`^[0-9a-f]{8}-[0-9a-f]{4}-...$`)
  - host/guest 로그인 시 **서로 다른 `deviceUuid`** 를 사용해야
   독립 세션이 유지됩니다 (동일 UUID 사용 시 세션 교체)
  - `dev` 환경의 Flyway Repeatable Migration이 자동 실행되어
  유저가 생성됩니다
