### PR TITLE
PR : feat/pvp-recording-timeout

### DIFF
--- a/src/main/java/com/imyme/mine/domain/pvp/service/PvpAsyncService.java
+++ b/src/main/java/com/imyme/mine/domain/pvp/service/PvpAsyncService.java
@@ -1,17 +1,22 @@
 package com.imyme.mine.domain.pvp.service;
 
+import com.imyme.mine.domain.auth.entity.User;
 import com.imyme.mine.domain.keyword.entity.Keyword;
 import com.imyme.mine.domain.keyword.repository.KeywordRepository;
 import com.imyme.mine.domain.pvp.entity.PvpRoom;
 import com.imyme.mine.domain.pvp.entity.PvpRoomStatus;
+import com.imyme.mine.domain.pvp.entity.PvpSubmission;
+import com.imyme.mine.domain.pvp.entity.PvpSubmissionStatus;
 import com.imyme.mine.domain.pvp.messaging.PvpChannels;
 import com.imyme.mine.domain.pvp.messaging.PvpMessage;
 import com.imyme.mine.domain.pvp.repository.PvpRoomRepository;
+import com.imyme.mine.domain.pvp.repository.PvpSubmissionRepository;
 import com.imyme.mine.global.messaging.MessagePublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +24,8 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * PvP 비동기 작업 서비스
@@ -31,9 +38,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PvpAsyncService {
 
+    private static final long RECORDING_TIMEOUT_MILLIS = 80_000L; // 1분 20초
+
     private final PvpRoomRepository pvpRoomRepository;
+    private final PvpSubmissionRepository pvpSubmissionRepository;
     private final KeywordRepository keywordRepository;
     private final MessagePublisher messagePublisher;
+    private final PvpMqConsumerService pvpMqConsumerService;
     private final com.imyme.mine.domain.pvp.websocket.PvpReadyManager pvpReadyManager;
 
     // Self-injection: 내부 @Async / @Transactional 메서드 호출 시 프록시를 거치도록
@@ -142,12 +153,131 @@ public class PvpAsyncService {
         pvpReadyManager.clearReady(roomId);
         log.info("RECORDING 타이머 자동 전환 완료: roomId={}", roomId);
 
-        // 커밋 후 Redis Pub/Sub 발행
+        // 커밋 후 Redis Pub/Sub 발행 + 타임아웃 예약
+        afterCommit(() -> {
+            messagePublisher.publish(PvpChannels.getRoomChannel(roomId),
+                    PvpMessage.recordingStarted(roomId));
+            self.scheduleRecordingTimeout(roomId);
+        });
+    }
+
+    // ===== RECORDING 타임아웃 =====
+
+    /**
+     * 80초 대기 후 RECORDING 타임아웃 처리
+     * - 미제출자가 있을 경우 자동으로 FAILED 처리 후 PROCESSING 전환
+     */
+    @Async
+    public void scheduleRecordingTimeout(Long roomId) {
+        try {
+            Thread.sleep(RECORDING_TIMEOUT_MILLIS);
+            self.doRecordingTimeout(roomId);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("RECORDING 타임아웃 중단: roomId={}", roomId, e);
+        }
+    }
+
+    /**
+     * RECORDING 타임아웃 핸들러
+     * - 비관적 락으로 방 조회
+     * - 미제출자 FAILED 처리 (레코드 없으면 생성, 동시성 방어)
+     * - 0명 제출: 방 취소 / 1명 이상 제출: PROCESSING 전환 + Feedback Request 발행
+     */
+    @Transactional
+    public void doRecordingTimeout(Long roomId) {
+        PvpRoom room = pvpRoomRepository.findByIdWithDetailsForUpdate(roomId).orElse(null);
+        if (room == null) {
+            log.warn("[Timeout] 방 없음: roomId={}", roomId);
+            return;
+        }
+
+        // 이미 RECORDING이 아니면 스킵 (정상 완료됨)
+        if (room.getStatus() != PvpRoomStatus.RECORDING) {
+            log.info("[Timeout] 스킵: 이미 전환됨 - roomId={}, status={}", roomId, room.getStatus());
+            return;
+        }
+
+        User host = room.getHostUser();
+        User guest = room.getGuestUser();
+        if (host == null || guest == null) {
+            log.warn("[Timeout] host/guest null: roomId={}", roomId);
+            return;
+        }
+
+        List<PvpSubmission> submissions = pvpSubmissionRepository.findByRoomIdWithUser(roomId);
+        Map<Long, PvpSubmission> submissionMap = submissions.stream()
+                .collect(Collectors.toMap(s -> s.getUser().getId(), s -> s));
+
+        int submittedCount = 0;
+        for (User user : List.of(host, guest)) {
+            PvpSubmission s = submissionMap.get(user.getId());
+
+            if (s == null) {
+                // 제출 레코드 자체가 없으면 FAILED 레코드 생성
+                try {
+                    PvpSubmission newS = PvpSubmission.builder()
+                            .room(room)
+                            .user(user)
+                            .build();
+                    newS.fail();
+                    pvpSubmissionRepository.save(newS);
+                    log.info("[Timeout] 미제출 FAILED 레코드 생성: roomId={}, userId={}", roomId, user.getId());
+                } catch (DataIntegrityViolationException e) {
+                    // 동시에 누군가 제출 레코드를 만든 경우 → 무시
+                    log.info("[Timeout] submission 동시 생성 감지: roomId={}, userId={}", roomId, user.getId());
+                }
+                continue;
+            }
+
+            if (s.getStatus() == PvpSubmissionStatus.PENDING) {
+                // presigned URL만 받고 제출 안 한 경우
+                s.fail();
+                pvpSubmissionRepository.save(s);
+                log.info("[Timeout] PENDING → FAILED: roomId={}, userId={}", roomId, user.getId());
+                continue;
+            }
+
+            // UPLOADED, PROCESSING, COMPLETED → 제출한 것으로 간주
+            submittedCount++;
+        }
+
+        if (submittedCount == 0) {
+            // 양쪽 모두 미제출 → 방 취소
+            room.cancel();
+            pvpRoomRepository.save(room);
+            log.info("[Timeout] 양쪽 미제출 → CANCELED: roomId={}", roomId);
+
+            afterCommit(() ->
+                    messagePublisher.publish(PvpChannels.getRoomChannel(roomId),
+                            PvpMessage.statusChange(roomId, PvpRoomStatus.CANCELED,
+                                    "제출 시간이 초과되어 방이 취소되었습니다."))
+            );
+            return;
+        }
+
+        // 1명 이상 제출 → PROCESSING 전환
+        room.startProcessing();
+        pvpRoomRepository.save(room);
+        log.info("[Timeout] PROCESSING 전환: roomId={}, submittedCount={}", roomId, submittedCount);
+
+        afterCommit(() -> {
+            messagePublisher.publish(PvpChannels.getRoomChannel(roomId),
+                    PvpMessage.statusChange(roomId, PvpRoomStatus.PROCESSING,
+                            "제출 시간이 종료되었습니다. AI 분석을 시작합니다."));
+
+            // Feedback Request 발행 (이미 STT 완료된 경우 대비)
+            pvpMqConsumerService.tryPublishFeedbackRequest(roomId);
+        });
+    }
+
+    // ===== Helper =====
+
+    private void afterCommit(Runnable action) {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                messagePublisher.publish(PvpChannels.getRoomChannel(roomId),
-                        PvpMessage.recordingStarted(roomId));
+                action.run();
             }
         });
     }

--- a/src/main/java/com/imyme/mine/domain/pvp/service/PvpMqConsumerService.java
+++ b/src/main/java/com/imyme/mine/domain/pvp/service/PvpMqConsumerService.java
@@ -102,7 +102,8 @@ public class PvpMqConsumerService {
      * - 양쪽 STT 완료(PROCESSING) 또는 한쪽 FAIL + 한쪽 완료 시 발행
      * - 비관적 락으로 중복 발행 방지
      */
-    private void tryPublishFeedbackRequest(Long roomId) {
+    @Transactional
+    public void tryPublishFeedbackRequest(Long roomId) {
         // 비관적 락으로 room 조회 (중복 발행 방지: SELECT ... FOR UPDATE)
         PvpRoom room = pvpRoomRepository.findByIdWithDetailsForUpdate(roomId).orElse(null);
         if (room == null) {

--- a/src/main/java/com/imyme/mine/domain/pvp/service/PvpRoomService.java
+++ b/src/main/java/com/imyme/mine/domain/pvp/service/PvpRoomService.java
@@ -266,12 +266,13 @@ public class PvpRoomService {
             pvpReadyManager.clearReady(roomId);
             log.info("양쪽 READY → RECORDING 즉시 전환: roomId={}", roomId);
 
-            // 커밋 후 RECORDING 브로드캐스트
+            // 커밋 후 RECORDING 브로드캐스트 + 타임아웃 예약
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
                     messagePublisher.publish(PvpChannels.getRoomChannel(roomId),
                             PvpMessage.recordingStarted(roomId));
+                    pvpAsyncService.scheduleRecordingTimeout(roomId);
                 }
             });
 


### PR DESCRIPTION
### Description
  RECORDING 상태에서 80초 제출 타임아웃을 적용해 미제출자를 자동 FAIL 처리하고, 게임 흐름이 멈추지 않도록 완결 처리합니다.

  ### Related Issues
  - Resolves #[203]

  ### Changes Made
  1. `PvpAsyncService`에 `scheduleRecordingTimeout()`/`doRecordingTimeout()` 추가 (80초 타임아웃)
  2. 미제출자 FAILED 처리 (레코드 없으면 생성, `DataIntegrityViolationException` 동시성 방어)
  3. 0명 제출 → CANCELED / 1명 이상 제출 → PROCESSING + Feedback Request 발행
  4. `doRecordingTransition()` afterCommit에 타임아웃 예약 추가
  5. `startRecording()` afterCommit에 타임아웃 예약 추가
  6. `tryPublishFeedbackRequest()`을 public + `@Transactional`로 변경

  ### Screenshots or Video
  N/A (백엔드 로직 변경)

  ### Testing
  1. `./gradlew compileJava` 빌드 성공 확인
  2. 양쪽 제출 완료 → 타임아웃 발동 시 RECORDING 아니므로 스킵
  3. 1명만 제출 → 80초 후 미제출자 FAILED + PROCESSING + Feedback Request 발행
  4. 0명 제출 → 80초 후 CANCELED 브로드캐스트

  ### Checklist
  - [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [x] 코드 리뷰어를 지정했습니다.

  ### Additional Notes
  - 타임아웃 예약 지점 2곳: `doRecordingTransition()` (30초 타이머 자동 전환), `startRecording()` (양쪽 READY 즉시 전환)
  - `tryPublishFeedbackRequest()` 내부 비관적 락 + `feedbackRequestedAt` 플래그로 중복 발행 방지
  - 시나리오 B (STT 이미 완료 + 미제출자) 대응: `doRecordingTimeout()`에서 PROCESSING 전환 후 `tryPublishFeedbackRequest()` 직접 호출