### PR TITLE
fix/infra: E2E_TEST OAuth Provider를 DB CHECK 제약 조건에 추가

### DIFF
--- a/src/main/resources/db/migration/V20260301_0011__add_e2e_test_oauth_provider.sql
+++ b/src/main/resources/db/migration/V20260301_0011__add_e2e_test_oauth_provider.sql
@@ -1,0 +1,7 @@
+-- E2E 테스트용 OAuth Provider 추가
+-- E2E 로그인 API (/e2e/login)에서 사용하는 Provider 타입
+
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_oauth_provider_check;
+
+ALTER TABLE users ADD CONSTRAINT users_oauth_provider_check
+CHECK (oauth_provider IN ('KAKAO', 'GOOGLE', 'APPLE', 'E2E_TEST'));


### PR DESCRIPTION
## Summary
- E2E 로그인 API (`/e2e/login`)에서 사용하는 `OAuthProviderType.E2E_TEST`가 DB CHECK 제약 조건에 누락되어 500 에러 발생하던 문제 수정
- Flyway 마이그레이션 파일 추가

## Test plan
- [x] release DB에 수동으로 적용 완료 (E2E 로그인 정상 작동 확인)
- [ ] 마이그레이션 파일 배포 후 다른 환경에서도 정상 작동 확인

