### PR TITLE
fix/infra: release 프로필에 JSON 로그 형식 적용

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -39,8 +39,8 @@
 <!--        <logger name="root" level="DEBUG"/>-->
     </springProfile>
 
-    <!-- ==================== PROD 환경: JSON 로그 (Loki용) ==================== -->
-    <springProfile name="prod">
+    <!-- ==================== PROD/RELEASE 환경: JSON 로그 (Loki용) ==================== -->
+    <springProfile name="prod,release">
         <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                 <includeMdcKeyName>clientIp</includeMdcKeyName>


### PR DESCRIPTION
## Summary
- release 환경에서도 prod와 동일하게 Loki용 JSON 로그 형식이 적용되도록 수정
- `springProfile`에 `release` 추가하여 JSON 로그 출력

## Test plan
- [ ] release 환경에서 로그가 JSON 형식으로 출력되는지 확인

