### PR TITLE
fix: release/prod 환경 Sentry debug 로그 비활성화

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -75,3 +75,9 @@ logging:
 knowledge:
     batch:
         enabled: false
+
+# Sentry 설정 (운영 환경용)
+sentry:
+    environment: prod
+    debug: false  # debug 로그 끔
+    traces-sample-rate: 0.1  # 10% 샘플링 (비용 절감)

--- a/src/main/resources/application-release.yml
+++ b/src/main/resources/application-release.yml
@@ -75,3 +75,9 @@ logging:
 knowledge:
     batch:
         enabled: false  # 필요 시 true로 변경
+
+# Sentry 설정 (운영 환경용)
+sentry:
+    environment: release
+    debug: false  # debug 로그 끔
+    traces-sample-rate: 0.1  # 10% 샘플링 (비용 절감)

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -102,5 +102,8 @@
         <!-- 서버 관련 -->
         <logger name="org.apache.catalina" level="WARN"/>
         <logger name="org.apache.coyote" level="WARN"/>
+
+        <!-- Sentry 로그 끄기 -->
+        <logger name="io.sentry" level="WARN"/>
     </springProfile>
 </configuration>


### PR DESCRIPTION
## Summary
- release/prod 환경에서 Sentry debug 로그가 Loki에 불필요하게 쌓이는 문제 해결
- `sentry.debug: false` 설정 추가
- logback에서 `io.sentry` 로거 WARN 레벨 설정

## Test plan
- [ ] release 환경 배포 후 Loki에서 Sentry debug 로그 확인
- [ ] 정상적인 애플리케이션 로그만 출력되는지 확인