### PR TITLE
PR :  Fix/pvp-recording-timeout-tx(#219)

### DIFF
--- a/src/main/java/com/imyme/mine/domain/pvp/dto/response/RoomResultResponse.java
+++ b/src/main/java/com/imyme/mine/domain/pvp/dto/response/RoomResultResponse.java
@@ -82,6 +82,8 @@ public class RoomResultResponse {
         private java.util.List<String> keywords;
         private String facts;
         private String understanding;
+
+        @com.fasterxml.jackson.annotation.JsonProperty("personalized_feedback")
         private String personalizedFeedback;
     }
 }

--- a/src/main/java/com/imyme/mine/domain/pvp/service/PvpAsyncService.java
+++ b/src/main/java/com/imyme/mine/domain/pvp/service/PvpAsyncService.java
@@ -261,14 +261,15 @@ public class PvpAsyncService {
         pvpRoomRepository.save(room);
         log.info("[Timeout] PROCESSING 전환: roomId={}, submittedCount={}", roomId, submittedCount);
 
-        afterCommit(() -> {
-            messagePublisher.publish(PvpChannels.getRoomChannel(roomId),
-                    PvpMessage.statusChange(roomId, PvpRoomStatus.PROCESSING,
-                            "제출 시간이 종료되었습니다. AI 분석을 시작합니다."));
+        // 트랜잭션 안에서 Feedback Request 발행 (비관적 락 필요)
+        pvpMqConsumerService.tryPublishFeedbackRequest(roomId);
 
-            // Feedback Request 발행 (이미 STT 완료된 경우 대비)
-            pvpMqConsumerService.tryPublishFeedbackRequest(roomId);
-        });
+        // afterCommit은 브로드캐스트만
+        afterCommit(() ->
+                messagePublisher.publish(PvpChannels.getRoomChannel(roomId),
+                        PvpMessage.statusChange(roomId, PvpRoomStatus.PROCESSING,
+                                "제출 시간이 종료되었습니다. AI 분석을 시작합니다."))
+        );
     }
 
     // ===== Helper =====


### PR DESCRIPTION
### Description

  - RECORDING 타임아웃 처리 중 tryPublishFeedbackRequest()가 트랜잭션 없이 실행되던 문제를 해결했습니다.
  - 결과 조회 응답의 비교피드백 필드를 snake_case(personalized_feedback)로 맞췄습니다.

  ### Related Issues

  - Resolves #[219]

  ### Changes Made

  1. doRecordingTimeout()에서 tryPublishFeedbackRequest() 호출을 **afterCommit 밖(트랜잭션 내부)**으로 이동
  2. RoomResultResponse.FeedbackDetail.personalizedFeedback에 @JsonProperty("personalized_feedback") 적용
  3. 타임아웃 처리 시 Feedback Request 발행 안정화

  ### Screenshots or Video

  - N/A (백엔드 로직/응답 스키마 변경)

  ### Testing

  1. RECORDING 타임아웃 발생 시 tryPublishFeedbackRequest()가 정상 호출되는지 확인
  2. 결과 조회 응답에 personalized_feedback 필드가 내려오는지 확인
  3. 기존 정상 흐름(두 명 제출)에서 이상 없는지 확인

  ### Checklist

  - [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  - tryPublishFeedbackRequest()는 findByIdWithDetailsForUpdate를 사용하므로 트랜잭션 외부 호출 시 오류가 발생했음.
  - personalized_feedback는 Swagger 스키마와 FE 기대값을 맞추기 위한 변경.

