### PR TITLE
PR : fix/pvp-feedback-casing

### DIFF
--- a/src/main/java/com/imyme/mine/domain/pvp/dto/response/RoomResultResponse.java
+++ b/src/main/java/com/imyme/mine/domain/pvp/dto/response/RoomResultResponse.java
@@ -82,8 +82,6 @@ public class RoomResultResponse {
         private java.util.List<String> keywords;
         private String facts;
         private String understanding;
-
-        @com.fasterxml.jackson.annotation.JsonProperty("personalized_feedback")
         private String personalizedFeedback;
     }
 }


### PR DESCRIPTION
### Description

  - PvP 결과 응답에서 비교피드백 필드명을 camelCase로 통일하여 FE 기대값과 맞췄습니다.

  ### Related Issues

  - Resolves #[221]

  ### Changes Made

  1. RoomResultResponse.FeedbackDetail의 personalizedFeedback 응답 필드를 camelCase로 통일
  2. @JsonProperty("personalized_feedback") 제거/수정으로 응답 스키마 정합성 확보

  ### Screenshots or Video

  - N/A (백엔드 응답 스키마 변경)

  ### Testing

  1. GET /pvp/rooms/{id}/result 응답에서 personalizedFeedback 필드가 내려오는지 확인
  2. FE에서 비교피드백 정상 출력 확인
  3. 기존 응답 필드(요약/키워드 등) 영향 없는지 확인

  ### Checklist

  - [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  - MQ 수신은 snake_case 스펙(personalized_feedback)을 유지하고 있으며, REST 응답만 camelCase로 통일했습니다.