### PR TITLE
PR :  Fix/release-timezone-config

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,6 +3,12 @@ spring:
         activate:
             on-profile: prod
 
+    # JSON 날짜 포맷 설정 (Prod에서도 KST 고정)
+    jackson:
+        serialization:
+            write-dates-as-timestamps: false
+        time-zone: Asia/Seoul
+
     flyway:
         locations: classpath:db/migration
 

--- a/src/main/resources/application-release.yml
+++ b/src/main/resources/application-release.yml
@@ -3,6 +3,12 @@ spring:
         activate:
             on-profile: release # 'release' 프로필일 때 활성화 (사전 프로덕션)
 
+    # JSON 날짜 포맷 설정 (Release에서도 KST 고정)
+    jackson:
+        serialization:
+            write-dates-as-timestamps: false
+        time-zone: Asia/Seoul
+
     flyway:
         locations: classpath:db/migration
         # Release는 실제 데이터 사용, testdata 제외


### PR DESCRIPTION
### Description

  Release/Prod 환경에서 타임존이 UTC로 내려오는 문제를 방지하기 위해 spring.jackson.time-zone을 명시적으로 설정했습니다.
  KST 기준으로 날짜/시간이 직렬화되도록 release/prod 설정에 반영합니다.

  ### Related Issues

  - Resolves #[231]

  ### Changes Made

  1. application-release.yml에 spring.jackson.time-zone: Asia/Seoul 추가
  2. application-prod.yml에 동일한 Jackson 타임존 설정 추가
  3. Release/Prod 환경에서 시간 직렬화 기준 통일

  ### Screenshots or Video

  N/A (설정 변경)

  ### Testing

  1. Release 프로필에서 THINKING 메시지 startedAt/thinkingEndsAt가 KST로 내려오는지 확인 예정
  2. JVM 타임존이 UTC인 환경에서도 Jackson 직렬화가 KST 기준인지 확인 예정

  ### Checklist

  - [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  - LocalDateTime은 타임존 정보가 없으므로, 서버 JVM 타임존이 UTC일 경우 TZ=Asia/Seoul 설정도 함께 권장합니다.