### PR TITLE
PR : Perf/vector-search-light-projection

### DIFF
--- a/src/main/java/com/imyme/mine/domain/knowledge/repository/KnowledgeBaseRepository.java
+++ b/src/main/java/com/imyme/mine/domain/knowledge/repository/KnowledgeBaseRepository.java
@@ -135,6 +135,30 @@ public interface KnowledgeBaseRepository extends JpaRepository<KnowledgeBase, Lo
     );
 
     /**
+     * 키워드별 벡터 유사도 검색 - 경량 버전 (embedding 제외)
+     * - evaluateCandidate()에서 embedding 미사용 → SELECT에서 제거
+     * - 결과 25건 기준 전송 payload 132KB → 29KB (77% 감소)
+     */
+    @Query(value = """
+        SELECT kb.id          AS id,
+               kb.keyword_id  AS keywordId,
+               kb.content     AS content,
+               kb.content_hash AS contentHash,
+               (kb.embedding <=> CAST(:queryEmbedding AS vector)) AS distance
+        FROM knowledge_base kb
+        WHERE kb.is_active = true
+          AND kb.embedding IS NOT NULL
+          AND kb.keyword_id = :keywordId
+        ORDER BY distance ASC
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<KnowledgeSearchResultLight> findSimilarKnowledgeByKeywordLight(
+        @Param("queryEmbedding") String queryEmbedding,
+        @Param("keywordId") Long keywordId,
+        @Param("limit") int limit
+    );
+
+    /**
      * 모든 활성 지식 조회 (최신순)
      * - 목적: 관리자 페이지에서 지식 목록 표시
      */

--- a/src/main/java/com/imyme/mine/domain/knowledge/repository/KnowledgeSearchResultLight.java
+++ b/src/main/java/com/imyme/mine/domain/knowledge/repository/KnowledgeSearchResultLight.java
@@ -1,0 +1,19 @@
+package com.imyme.mine.domain.knowledge.repository;
+
+/**
+ * 벡터 유사도 검색 경량 결과 Projection (embedding 제외)
+ * - evaluateCandidate()에서 content, distance, id만 사용하므로 embedding 전송 불필요
+ * - 결과 25건 기준 DB→앱 전송 payload 132KB → 29KB (77% 감소)
+ */
+public interface KnowledgeSearchResultLight {
+
+    Long getId();
+
+    Long getKeywordId();
+
+    String getContent();
+
+    String getContentHash();
+
+    Double getDistance();
+}

--- a/src/main/java/com/imyme/mine/domain/learning/service/KnowledgeBatchService.java
+++ b/src/main/java/com/imyme/mine/domain/learning/service/KnowledgeBatchService.java
@@ -8,6 +8,7 @@ import com.imyme.mine.domain.card.repository.CardFeedbackRepository;
 import com.imyme.mine.domain.knowledge.entity.KnowledgeBase;
 import com.imyme.mine.domain.knowledge.repository.KnowledgeBaseRepository;
 import com.imyme.mine.domain.knowledge.repository.KnowledgeSearchResult;
+import com.imyme.mine.domain.knowledge.repository.KnowledgeSearchResultLight;
 import com.imyme.mine.domain.keyword.entity.Keyword;
 import com.imyme.mine.domain.keyword.repository.KeywordRepository;
 import com.imyme.mine.domain.learning.dto.KnowledgeBatchResult;
@@ -411,9 +412,9 @@ public class KnowledgeBatchService {
     private CandidateDecision evaluateCandidate(KnowledgeCandidate candidate, Long keywordId) {
         String embeddingVector = convertEmbeddingToString(candidate.embedding());
 
-        // 유사 지식 검색
-        List<KnowledgeSearchResult> similars = knowledgeRepository
-            .findSimilarKnowledgeByKeyword(
+        // 유사 지식 검색 (경량 버전: embedding 제외로 payload 77% 감소)
+        List<KnowledgeSearchResultLight> similars = knowledgeRepository
+            .findSimilarKnowledgeByKeywordLight(
                 embeddingVector,
                 keywordId,
                 properties.getMaxSimilarCount()
@@ -421,7 +422,7 @@ public class KnowledgeBatchService {
 
         // 유사도 임계값 필터링
         double threshold = 1.0 - properties.getSimilarityThreshold();
-        List<KnowledgeSearchResult> filteredSimilars = similars.stream()
+        List<KnowledgeSearchResultLight> filteredSimilars = similars.stream()
             .filter(s -> s.getDistance() <= threshold)
             .collect(Collectors.toList());
 
@@ -570,7 +571,7 @@ public class KnowledgeBatchService {
      */
     private KnowledgeEvaluationRequest buildEvaluationRequest(
         KnowledgeCandidate candidate,
-        List<KnowledgeSearchResult> similars
+        List<KnowledgeSearchResultLight> similars
     ) {
         // EvaluationCandidate(String text, String sourceId)
         EvaluationCandidate evalCandidate = new EvaluationCandidate(


### PR DESCRIPTION
### Description

  Vector search 결과에서 embedding 컬럼을 제거하여 응답 payload를 대폭 축소했습니다.
  동일한 top‑K 결과 기준 132,304B → 29,804B (약 77.5% 감소) 확인했습니다.

  ### Related Issues

  - Resolves #[115]

  ### Changes Made

  1. KnowledgeSearchResultLight Projection 추가 (embedding 제외)
  2. KnowledgeBaseRepository에 경량 조회 쿼리 추가
  3. KnowledgeBatchService.evaluateCandidate()에서 경량 조회로 전환

  ### Screenshots or Video

  - N/A (백엔드 로직 변경)

  ### Testing

  1. 로컬 DB에서 pg_column_size 기반 payload 측정
  2. Before/After 쿼리 실행 결과 비교 (132,304B → 29,804B)

  ### Checklist

  - [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [ ] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  - DB 실행 시간보다는 전송 payload 감소 효과가 핵심입니다.
  - 실제 비교는 동일 top‑K 기준 pg_column_size로 측정했습니다.