### PR TITLE
PR : Fix/solo-mq-enable

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -52,6 +52,10 @@ spring:
                     max-attempts: 3
                     multiplier: 2.0
 
+solo:
+    mq:
+        enabled: true  # MQ 경로 활성화 (AI 서버가 solo.stt.request 큐로 전환)
+
 logging:
     level:
         com.imyme.mine: DEBUG


### PR DESCRIPTION
### Description

  Solo STT/Feedback 경로를 MQ로 전환하기 위해 solo.mq.enabled 값을 활성화합니다.
  AI 서버가 HTTP STT 엔드포인트를 제거한 상태이므로, BE도 MQ 경로를 사용해야 정상 처리됩니다.

  ### Related Issues

  - Resolves #[251]

  ### Changes Made

  1. solo.mq.enabled를 true로 변경 (환경 설정)
  2. Solo STT/Feedback 요청이 MQ 경로로 전환됨
  3. HTTP 기반 Solo STT 호출 제거/미사용 경로 확정

  ### Screenshots or Video

  N/A

  ### Testing

  1. Solo 시도 업로드 → [Solo MQ] STT Request 발행 로그 확인
  2. AI가 solo.stt.request 소비 후 응답 큐 발행 확인
  3. SSE로 COMPLETED / FAILED 이벤트 수신 확인

  ### Checklist

  - [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  - AI 서버는 HTTP /api/v1/transcriptions 엔드포인트를 제거했으므로, MQ 활성화가 필수입니다.