### PR TITLE
PR : Fix/enable-solo-mq-release-prod

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -77,6 +77,10 @@ logging:
         # 운영에선 쿼리 로그 끄거나 에러만 봄
         org.hibernate.SQL: WARN
 
+solo:
+    mq:
+        enabled: true  # AI 서버가 MQ 경로로 전환 (HTTP /transcriptions 엔드포인트 제거됨)
+
 # (선택) 운영 환경에서 배치 작업을 켜려면 여기서 설정
 knowledge:
     batch:

--- a/src/main/resources/application-release.yml
+++ b/src/main/resources/application-release.yml
@@ -77,6 +77,10 @@ logging:
         org.springframework.security: INFO
         org.hibernate.SQL: WARN
 
+solo:
+    mq:
+        enabled: true  # AI 서버가 MQ 경로로 전환 (HTTP /transcriptions 엔드포인트 제거됨)
+
 # Release 환경에서 배치 작업 설정 (Prod 검증용)
 knowledge:
     batch:


### PR DESCRIPTION
 ### Description

  release/prod 환경에서 Solo STT 요청이 여전히 HTTP 동기 호출 경로를 사용하고 있어 upload-complete 처리 중 STT_RECOGNIZE_FAILED가 발생하는 문제를 수정합니다.
  AI 서버의 Solo HTTP STT 엔드포인트 제거에 맞춰 release/prod 모두 MQ 경로를 사용하도록 설정을 변경합니다.

  ### Related Issues

  - Resolves #[이슈 번호]

  ### Changes Made

  1. application-release.yml에 solo.mq.enabled: true 설정을 추가했습니다.
  2. application-prod.yml에 solo.mq.enabled: true 설정을 추가했습니다.
  3. release/prod 환경에서 upload-complete 이후 Solo STT 요청이 HTTP 호출 대신 MQ 발행 경로를 사용하도록 정렬했습니다.

  ### Screenshots or Video

  - 해당 없음

  ### Testing

  1. release 프로필 기준으로 upload-complete 호출 시 Solo STT가 HTTP 동기 호출이 아닌 MQ 발행 경로를 타는지 확인했습니다.
  2. release/prod 설정에서 solo.mq.enabled override가 정상 적용되는지 확인했습니다.
  3. 기존 STT_RECOGNIZE_FAILED 재현 케이스 기준으로 HTTP STT 호출 로그가 발생하지 않는지 확인했습니다.

  ### Checklist

  - [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  - 기본 설정인 application.yml에서는 solo.mq.enabled: false입니다.
  - dev 환경은 이미 MQ 경로를 사용하고 있지만, release/prod에는 override가 없어 동기 HTTP STT 경로를 사용하고 있었습니다.
  - 배포 후에는 upload-complete 요청 시 solo.stt.request 큐 적재 여부와 consumer 처리 로그를 함께 확인할 예정입니다.