### PR TITLE
PR : Fix/challenge-upload-flow

### DIFF
--- a/src/main/java/com/imyme/mine/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/imyme/mine/domain/challenge/controller/ChallengeController.java
@@ -154,8 +154,10 @@ public class ChallengeController {
     @Operation(
             summary = "챌린지 참여 시작",
             description = "챌린지에 참여를 시작하고 S3 업로드용 Presigned URL을 발급합니다. "
+                    + "요청 바디에 contentType만 포함합니다 (fileSize는 녹음 전 알 수 없으므로 upload-complete 시 검증). "
                     + "PENDING 상태의 기존 참여가 있으면 새 URL을 재발급합니다 (200). "
-                    + "신규 참여면 201을 반환합니다.",
+                    + "신규 참여면 201을 반환합니다. "
+                    + "클라이언트는 S3 PUT 업로드 시 createAttempt에 보낸 것과 동일한 Content-Type 헤더를 포함해야 합니다.",
             security = @SecurityRequirement(name = "JWT")
     )
     @ApiResponses({
@@ -169,7 +171,7 @@ public class ChallengeController {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
-                    description = "챌린지 미시작 - CHALLENGE_NOT_STARTED",
+                    description = "챌린지 미시작(CHALLENGE_NOT_STARTED) / 허용되지 않는 파일 형식(INVALID_CONTENT_TYPE)",
                     content = @Content(schema = @Schema(ref = "#/components/schemas/ErrorResponse"))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -214,7 +216,9 @@ public class ChallengeController {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
-                    description = "S3 업로드 미완료(UPLOAD_NOT_COMPLETED) / 챌린지 미시작(CHALLENGE_NOT_STARTED) / 잘못된 Object Key(INVALID_OBJECT_KEY)",
+                    description = "S3 업로드 미완료(UPLOAD_NOT_COMPLETED) / 챌린지 미시작(CHALLENGE_NOT_STARTED) / "
+                            + "잘못된 Object Key(INVALID_OBJECT_KEY) / "
+                            + "허용되지 않은 파일 형식(INVALID_CONTENT_TYPE) / 파일 크기 초과(FILE_TOO_LARGE)",
                     content = @Content(schema = @Schema(ref = "#/components/schemas/ErrorResponse"))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/imyme/mine/domain/challenge/dto/request/CompleteUploadRequest.java
+++ b/src/main/java/com/imyme/mine/domain/challenge/dto/request/CompleteUploadRequest.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.NotNull;
  * 업로드 완료 확정 요청 (POST /challenges/{challengeId}/attempts/{attemptId}/upload-complete)
  */
 public record CompleteUploadRequest(
-        @Schema(description = "S3 Object Key (참여 시작 응답에서 받은 값)", example = "challenges/1/2/3_uuid.webm")
+        @Schema(description = "S3 Object Key (참여 시작 응답에서 받은 값)", example = "challenges/1/2/3_uuid")
         @NotBlank String objectKey,
 
         @Schema(description = "녹음 길이 (초)", example = "45")

--- a/src/main/java/com/imyme/mine/domain/challenge/dto/request/CreateAttemptRequest.java
+++ b/src/main/java/com/imyme/mine/domain/challenge/dto/request/CreateAttemptRequest.java
@@ -2,19 +2,15 @@ package com.imyme.mine.domain.challenge.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Pattern;
 
 /**
  * 챌린지 참여 시작 요청 (POST /challenges/{challengeId}/attempts)
+ * - fileSize는 녹음 전 알 수 없으므로 받지 않음 — upload-complete 시 HeadObject로 검증
  */
 public record CreateAttemptRequest(
-        @Schema(description = "파일 이름", example = "recording.webm")
-        @NotBlank String fileName,
-
-        @Schema(description = "파일 MIME 타입 (audio/webm, audio/mp4, audio/m4a)", example = "audio/webm")
-        @NotBlank String contentType,
-
-        @Schema(description = "파일 크기 (바이트, 최대 10MB)", example = "1048576")
-        @NotNull @Positive Long fileSize
+        @Schema(description = "파일 MIME 타입 (audio/webm, audio/mp4, audio/m4a, audio/mpeg, audio/wav)", example = "audio/webm")
+        @NotBlank
+        @Pattern(regexp = "audio/(webm|mp4|m4a|mpeg|wav)(;.*)?", message = "허용되지 않는 파일 형식입니다.")
+        String contentType
 ) {}

--- a/src/main/java/com/imyme/mine/domain/challenge/dto/response/CreateAttemptResponse.java
+++ b/src/main/java/com/imyme/mine/domain/challenge/dto/response/CreateAttemptResponse.java
@@ -20,7 +20,7 @@ public record CreateAttemptResponse(
         @Schema(description = "S3 업로드용 Presigned PUT URL")
         String uploadUrl,
 
-        @Schema(description = "S3 Object Key (upload-complete 요청 시 전달)", example = "challenges/1/2/3_uuid.webm")
+        @Schema(description = "S3 Object Key (upload-complete 요청 시 전달)", example = "challenges/1/2/3_uuid")
         String objectKey,
 
         @Schema(description = "URL 유효기간 (초)", example = "300")

--- a/src/main/java/com/imyme/mine/domain/challenge/service/ChallengeAttemptService.java
+++ b/src/main/java/com/imyme/mine/domain/challenge/service/ChallengeAttemptService.java
@@ -70,13 +70,20 @@ public class ChallengeAttemptService {
             if (attempt.getStatus() != ChallengeAttemptStatus.PENDING) {
                 throw new BusinessException(ErrorCode.ALREADY_PARTICIPATED);
             }
-            // PENDING 재사용: 새 objectKey를 발급하고 이전 업로드(audioKey)를 무효화한다.
-            // 클라이언트가 URL만 재발급받길 원해도 이전 S3 업로드 파일은 더 이상 사용되지 않는다.
-            String[] ticket = storageService.generateChallengePresignedUrl(
-                    userId, challengeId, attempt.getId(), request.contentType(), request.fileSize());
-            attempt.refreshUploadReservation(ticket[0]);
+            // PENDING 재사용: 기존 objectKey 재사용 → orphan 파일 방지
+            // audioKey가 이미 있으면 동일 key로 presigned URL만 재발급, 없으면 신규 생성
+            String uploadUrl;
+            if (attempt.getAudioKey() != null) {
+                uploadUrl = storageService.reissueChallengePresignedUrl(
+                        attempt.getAudioKey(), request.contentType());
+            } else {
+                String[] ticket = storageService.generateChallengePresignedUrl(
+                        userId, challengeId, attempt.getId(), request.contentType());
+                attempt.refreshUploadReservation(ticket[0]);
+                uploadUrl = ticket[1];
+            }
 
-            return Map.entry(buildCreateAttemptResponse(attempt, challengeId, ticket[1]), false);
+            return Map.entry(buildCreateAttemptResponse(attempt, challengeId, uploadUrl), false);
         }
 
         // 신규 생성
@@ -88,7 +95,7 @@ public class ChallengeAttemptService {
         challengeAttemptRepository.save(attempt);
 
         String[] ticket = storageService.generateChallengePresignedUrl(
-                userId, challengeId, attempt.getId(), request.contentType(), request.fileSize());
+                userId, challengeId, attempt.getId(), request.contentType());
         attempt.refreshUploadReservation(ticket[0]);
 
         log.info("[Challenge] 참여 시작 - challengeId={}, userId={}, attemptId={}",
@@ -122,9 +129,7 @@ public class ChallengeAttemptService {
             throw new BusinessException(ErrorCode.INVALID_OBJECT_KEY);
         }
 
-        if (!storageService.doesObjectExist(request.objectKey())) {
-            throw new BusinessException(ErrorCode.UPLOAD_NOT_COMPLETED);
-        }
+        storageService.validateChallengeObjectMetadata(request.objectKey());
 
         attempt.markUploadCompleted(request.objectKey(), request.durationSeconds());
 

--- a/src/main/java/com/imyme/mine/domain/storage/service/StorageService.java
+++ b/src/main/java/com/imyme/mine/domain/storage/service/StorageService.java
@@ -54,7 +54,9 @@ public class StorageService {
     private static final Set<String> CHALLENGE_ALLOWED_CONTENT_TYPES = Set.of(
         "audio/webm",
         "audio/mp4",
-        "audio/m4a"
+        "audio/m4a",
+        "audio/mpeg",
+        "audio/wav"
     );
 
     private static final long MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
@@ -249,34 +251,30 @@ public class StorageService {
 
     /**
      * 챌린지 녹음 제출용 Presigned PUT URL 발급
-     * - 챌린지 전용 10MB 제한, webm/mp4 허용
+     * - contentType 사전 검증 후 presigned PUT에 Content-Type 제약 포함
+     * - fileSize는 받지 않음 — upload-complete 시 HeadObject로 검증
+     * - audio/m4a alias 정규화 없음: 프론트 PUT 헤더와 일치시키기 위해 입력값 그대로 사용
+     * - 클라이언트는 S3 PUT 요청 시 createAttempt에 보낸 것과 동일한 Content-Type 헤더 필수
      *
      * @return [objectKey, uploadUrl] — objectKey는 attempt에 저장, uploadUrl은 클라이언트에 전달
      */
     public String[] generateChallengePresignedUrl(
-            Long userId, Long challengeId, Long attemptId, String contentType, Long fileSize) {
-
-        if (fileSize > CHALLENGE_MAX_FILE_SIZE) {
-            throw new BusinessException(ErrorCode.FILE_TOO_LARGE);
-        }
+            Long userId, Long challengeId, Long attemptId, String contentType) {
 
         String raw = contentType == null ? null : contentType.split(";")[0].trim().toLowerCase();
         if (raw == null || !CHALLENGE_ALLOWED_CONTENT_TYPES.contains(raw)) {
             throw new BusinessException(ErrorCode.INVALID_CONTENT_TYPE);
         }
-        // audio/m4a → audio/mp4 alias
-        final String normalized = "audio/m4a".equals(raw) ? "audio/mp4" : raw;
 
-        String extension = getExtensionFromContentType(normalized);
-        String objectKey = String.format("challenges/%d/%d/%d_%s.%s",
-                userId, challengeId, attemptId, UUID.randomUUID(), extension);
+        String objectKey = String.format("challenges/%d/%d/%d_%s",
+                userId, challengeId, attemptId, UUID.randomUUID());
 
         PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
                 .signatureDuration(Duration.ofMinutes(CHALLENGE_URL_EXPIRATION_MINUTES))
                 .putObjectRequest(builder -> builder
                         .bucket(s3Properties.getBucket())
                         .key(objectKey)
-                        .contentType(normalized)
+                        .contentType(raw)
                 )
                 .build();
 
@@ -286,24 +284,69 @@ public class StorageService {
     }
 
     /**
-     * S3 오브젝트 존재 여부 확인 (upload-complete 검증용)
-     * - NoSuchKeyException: 객체 없음 (404)
-     * - S3Exception 404/403: 접근 불가 또는 존재하지 않음 → false 처리
-     * - 그 외 예외: 인프라 이상으로 상위로 전파
+     * 챌린지 PENDING 재발급 — 기존 objectKey 재사용
+     * - 새 UUID 없이 동일 key로 presigned URL만 재발급 → orphan 파일 방지
+     * - contentType 사전 검증 수행 (신규 발급과 동일 정책)
+     *
+     * @return uploadUrl — 클라이언트에 전달할 새 presigned PUT URL
      */
-    public boolean doesObjectExist(String objectKey) {
+    public String reissueChallengePresignedUrl(String objectKey, String contentType) {
+        String raw = contentType == null ? null : contentType.split(";")[0].trim().toLowerCase();
+        if (raw == null || !CHALLENGE_ALLOWED_CONTENT_TYPES.contains(raw)) {
+            throw new BusinessException(ErrorCode.INVALID_CONTENT_TYPE);
+        }
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(CHALLENGE_URL_EXPIRATION_MINUTES))
+                .putObjectRequest(builder -> builder
+                        .bucket(s3Properties.getBucket())
+                        .key(objectKey)
+                        .contentType(raw)
+                )
+                .build();
+
+        String uploadUrl = s3Presigner.presignPutObject(presignRequest).url().toString();
+        log.info("챌린지 Presigned URL 재발급 - objectKey={}", objectKey);
+        return uploadUrl;
+    }
+
+    /**
+     * 챌린지 upload-complete 시 S3 HeadObject로 실제 파일 메타데이터 검증
+     * - 객체 없음 → UPLOAD_NOT_COMPLETED
+     * - 허용되지 않은 content-type → 즉시 deleteObject 후 INVALID_CONTENT_TYPE
+     * - 10MB 초과 → 즉시 deleteObject 후 FILE_TOO_LARGE
+     */
+    public void validateChallengeObjectMetadata(String objectKey) {
+        software.amazon.awssdk.services.s3.model.HeadObjectResponse head;
         try {
-            s3Client.headObject(builder -> builder.bucket(s3Properties.getBucket()).key(objectKey));
-            return true;
+            head = s3Client.headObject(builder -> builder.bucket(s3Properties.getBucket()).key(objectKey));
         } catch (NoSuchKeyException e) {
-            return false;
+            throw new BusinessException(ErrorCode.UPLOAD_NOT_COMPLETED);
         } catch (S3Exception e) {
-            int status = e.statusCode();
-            if (status == 404 || status == 403) {
-                log.warn("S3 오브젝트 접근 불가 - key={}, status={}", objectKey, status);
-                return false;
+            if (e.statusCode() == 404 || e.statusCode() == 403) {
+                throw new BusinessException(ErrorCode.UPLOAD_NOT_COMPLETED);
             }
             throw e;
+        }
+
+        String raw = head.contentType() == null ? null
+                : head.contentType().split(";")[0].trim().toLowerCase();
+        if (raw == null || !CHALLENGE_ALLOWED_CONTENT_TYPES.contains(raw)) {
+            deleteObjectQuietly(objectKey);
+            throw new BusinessException(ErrorCode.INVALID_CONTENT_TYPE);
+        }
+
+        if (head.contentLength() > CHALLENGE_MAX_FILE_SIZE) {
+            deleteObjectQuietly(objectKey);
+            throw new BusinessException(ErrorCode.FILE_TOO_LARGE);
+        }
+    }
+
+    private void deleteObjectQuietly(String objectKey) {
+        try {
+            deleteObject(objectKey);
+        } catch (Exception e) {
+            log.warn("[Challenge] 무효 파일 삭제 실패 - objectKey={}, error={}", objectKey, e.getMessage());
         }
     }
 

--- a/src/test/java/com/imyme/mine/domain/challenge/service/ChallengeAttemptServiceTest.java
+++ b/src/test/java/com/imyme/mine/domain/challenge/service/ChallengeAttemptServiceTest.java
@@ -1,0 +1,155 @@
+package com.imyme.mine.domain.challenge.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.imyme.mine.domain.auth.entity.User;
+import com.imyme.mine.domain.auth.repository.UserRepository;
+import com.imyme.mine.domain.challenge.dto.request.CompleteUploadRequest;
+import com.imyme.mine.domain.challenge.dto.request.CreateAttemptRequest;
+import com.imyme.mine.domain.challenge.dto.response.CreateAttemptResponse;
+import com.imyme.mine.domain.challenge.entity.Challenge;
+import com.imyme.mine.domain.challenge.entity.ChallengeAttempt;
+import com.imyme.mine.domain.challenge.entity.ChallengeAttemptStatus;
+import com.imyme.mine.domain.challenge.entity.ChallengeStatus;
+import com.imyme.mine.domain.challenge.repository.ChallengeAttemptRepository;
+import com.imyme.mine.domain.challenge.repository.ChallengeRankingRepository;
+import com.imyme.mine.domain.challenge.repository.ChallengeRepository;
+import com.imyme.mine.domain.challenge.repository.ChallengeResultRepository;
+import com.imyme.mine.domain.storage.service.StorageService;
+import com.imyme.mine.global.error.BusinessException;
+import com.imyme.mine.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@DisplayName("ChallengeAttemptService 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class ChallengeAttemptServiceTest {
+
+    @Mock ChallengeRepository challengeRepository;
+    @Mock ChallengeAttemptRepository challengeAttemptRepository;
+    @Mock ChallengeRankingRepository challengeRankingRepository;
+    @Mock ChallengeResultRepository challengeResultRepository;
+    @Mock UserRepository userRepository;
+    @Mock StorageService storageService;
+    @Mock ObjectMapper objectMapper;
+
+    @InjectMocks
+    ChallengeAttemptService challengeAttemptService;
+
+    // =========================================================================
+    // 참여 시작 — contentType 포함 요청으로 presigned URL 발급
+    // =========================================================================
+
+    @Test
+    @DisplayName("참여 시작 - 신규 생성 시 presigned URL 발급 (HTTP 201)")
+    void createAttempt_newAttempt_returnsPresignedUrl() {
+        Challenge challenge = mock(Challenge.class);
+        when(challenge.getStatus()).thenReturn(ChallengeStatus.OPEN);
+        User user = mock(User.class);
+
+        when(challengeRepository.findByIdWithKeyword(1L)).thenReturn(Optional.of(challenge));
+        when(challengeAttemptRepository.findByChallengeIdAndUserId(1L, 10L)).thenReturn(Optional.empty());
+        when(userRepository.getReferenceById(10L)).thenReturn(user);
+
+        // 신규 attempt는 저장 전 ID가 null이므로 any() 사용
+        when(storageService.generateChallengePresignedUrl(eq(10L), eq(1L), any(), eq("audio/webm")))
+                .thenReturn(new String[]{"challenges/10/1/100_uuid", "https://s3.presigned.url"});
+
+        CreateAttemptRequest request = new CreateAttemptRequest("audio/webm");
+        Map.Entry<CreateAttemptResponse, Boolean> result =
+                challengeAttemptService.createAttempt(1L, 10L, request);
+
+        assertThat(result.getValue()).isTrue(); // 신규 생성 → HTTP 201
+        assertThat(result.getKey().uploadUrl()).isEqualTo("https://s3.presigned.url");
+        assertThat(result.getKey().objectKey()).isEqualTo("challenges/10/1/100_uuid");
+        verify(storageService).generateChallengePresignedUrl(eq(10L), eq(1L), any(), eq("audio/webm"));
+    }
+
+    @Test
+    @DisplayName("참여 시작 - PENDING 재사용 시 기존 objectKey로 URL 재발급 (HTTP 200)")
+    void createAttempt_pendingReuse_reusesExistingObjectKey() {
+        Challenge challenge = mock(Challenge.class);
+        when(challenge.getStatus()).thenReturn(ChallengeStatus.OPEN);
+
+        ChallengeAttempt existing = mock(ChallengeAttempt.class);
+        when(existing.getId()).thenReturn(99L);
+        when(existing.getStatus()).thenReturn(ChallengeAttemptStatus.PENDING);
+        when(existing.getAudioKey()).thenReturn("challenges/10/1/99_existing_uuid");
+
+        when(challengeRepository.findByIdWithKeyword(1L)).thenReturn(Optional.of(challenge));
+        when(challengeAttemptRepository.findByChallengeIdAndUserId(1L, 10L)).thenReturn(Optional.of(existing));
+        when(storageService.reissueChallengePresignedUrl("challenges/10/1/99_existing_uuid", "audio/mp4"))
+                .thenReturn("https://s3.presigned.url2");
+
+        CreateAttemptRequest request = new CreateAttemptRequest("audio/mp4");
+        Map.Entry<CreateAttemptResponse, Boolean> result =
+                challengeAttemptService.createAttempt(1L, 10L, request);
+
+        assertThat(result.getValue()).isFalse(); // 재사용 → HTTP 200
+        assertThat(result.getKey().objectKey()).isEqualTo("challenges/10/1/99_existing_uuid");
+        // 기존 objectKey 재사용 → generateChallengePresignedUrl 호출 안 됨
+        verify(storageService, never()).generateChallengePresignedUrl(any(), any(), any(), any());
+        verify(storageService).reissueChallengePresignedUrl("challenges/10/1/99_existing_uuid", "audio/mp4");
+    }
+
+    // =========================================================================
+    // 업로드 완료 — validateChallengeObjectMetadata 호출 검증
+    // =========================================================================
+
+    @Test
+    @DisplayName("업로드 완료 - validateChallengeObjectMetadata 호출")
+    void completeUpload_callsValidateMetadata() {
+        Challenge challenge = mock(Challenge.class);
+        when(challenge.getStatus()).thenReturn(ChallengeStatus.OPEN);
+
+        ChallengeAttempt attempt = mock(ChallengeAttempt.class);
+        when(attempt.getStatus()).thenReturn(ChallengeAttemptStatus.PENDING);
+        when(attempt.getChallenge()).thenReturn(challenge);
+        when(attempt.getAudioKey()).thenReturn("challenges/10/1/100_uuid");
+
+        when(challengeAttemptRepository.findByIdAndChallengeIdAndUserId(100L, 1L, 10L))
+                .thenReturn(Optional.of(attempt));
+
+        CompleteUploadRequest request = new CompleteUploadRequest("challenges/10/1/100_uuid", 45);
+
+        challengeAttemptService.completeUpload(1L, 100L, 10L, request);
+
+        verify(storageService).validateChallengeObjectMetadata("challenges/10/1/100_uuid");
+    }
+
+    @Test
+    @DisplayName("업로드 완료 - objectKey 불일치 시 INVALID_OBJECT_KEY 예외")
+    void completeUpload_objectKeyMismatch_throwsException() {
+        Challenge challenge = mock(Challenge.class);
+        when(challenge.getStatus()).thenReturn(ChallengeStatus.OPEN);
+
+        ChallengeAttempt attempt = mock(ChallengeAttempt.class);
+        when(attempt.getStatus()).thenReturn(ChallengeAttemptStatus.PENDING);
+        when(attempt.getChallenge()).thenReturn(challenge);
+        when(attempt.getAudioKey()).thenReturn("challenges/10/1/100_uuid");
+
+        when(challengeAttemptRepository.findByIdAndChallengeIdAndUserId(100L, 1L, 10L))
+                .thenReturn(Optional.of(attempt));
+
+        CompleteUploadRequest request = new CompleteUploadRequest("challenges/10/1/other_key", 45);
+
+        assertThatThrownBy(() -> challengeAttemptService.completeUpload(1L, 100L, 10L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_OBJECT_KEY);
+
+        verify(storageService, never()).validateChallengeObjectMetadata(any());
+    }
+}

--- a/src/test/java/com/imyme/mine/domain/storage/service/StorageServiceChallengeTest.java
+++ b/src/test/java/com/imyme/mine/domain/storage/service/StorageServiceChallengeTest.java
@@ -1,0 +1,193 @@
+package com.imyme.mine.domain.storage.service;
+
+import com.imyme.mine.domain.card.repository.CardAttemptRepository;
+import com.imyme.mine.global.config.AttemptProperties;
+import com.imyme.mine.global.config.S3Properties;
+import com.imyme.mine.global.error.BusinessException;
+import com.imyme.mine.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DisplayName("StorageService 챌린지 검증 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class StorageServiceChallengeTest {
+
+    @Mock S3Client s3Client;
+    @Mock S3Presigner s3Presigner;
+    @Mock S3Properties s3Properties;
+    @Mock CardAttemptRepository cardAttemptRepository;
+    @Mock AttemptProperties attemptProperties;
+
+    @InjectMocks
+    StorageService storageService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(s3Properties.getBucket()).thenReturn("test-bucket");
+    }
+
+    // =========================================================================
+    // generateChallengePresignedUrl — contentType 사전 검증
+    // =========================================================================
+
+    @ParameterizedTest
+    @ValueSource(strings = {"audio/webm", "audio/mp4", "audio/m4a", "audio/mpeg", "audio/wav"})
+    @DisplayName("generateChallengePresignedUrl - 허용 타입 5종 모두 통과")
+    void generatePresignedUrl_allowedTypes_noException(String contentType) throws MalformedURLException {
+        PresignedPutObjectRequest presigned = mock(PresignedPutObjectRequest.class);
+        when(presigned.url()).thenReturn(new URL("https://s3.presigned.url"));
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenReturn(presigned);
+
+        assertThatCode(() -> storageService.generateChallengePresignedUrl(1L, 1L, 1L, contentType))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("generateChallengePresignedUrl - 허용되지 않는 타입(video/mp4) → INVALID_CONTENT_TYPE")
+    void generatePresignedUrl_invalidType_throwsException() {
+        assertThatThrownBy(() -> storageService.generateChallengePresignedUrl(1L, 1L, 1L, "video/mp4"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_CONTENT_TYPE);
+    }
+
+    @Test
+    @DisplayName("generateChallengePresignedUrl - null contentType → INVALID_CONTENT_TYPE")
+    void generatePresignedUrl_nullType_throwsException() {
+        assertThatThrownBy(() -> storageService.generateChallengePresignedUrl(1L, 1L, 1L, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_CONTENT_TYPE);
+    }
+
+    // =========================================================================
+    // reissueChallengePresignedUrl — PENDING 재발급 (기존 objectKey 재사용)
+    // =========================================================================
+
+    @Test
+    @DisplayName("reissueChallengePresignedUrl - 기존 objectKey로 새 presigned URL 발급")
+    void reissuePresignedUrl_existingKey_returnsNewUrl() throws MalformedURLException {
+        PresignedPutObjectRequest presigned = mock(PresignedPutObjectRequest.class);
+        when(presigned.url()).thenReturn(new URL("https://s3.reissued.url"));
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenReturn(presigned);
+
+        String url = storageService.reissueChallengePresignedUrl("challenges/1/1/99_existing", "audio/webm");
+
+        assertThat(url).isEqualTo("https://s3.reissued.url");
+        verify(s3Presigner).presignPutObject(any(PutObjectPresignRequest.class));
+    }
+
+    @Test
+    @DisplayName("reissueChallengePresignedUrl - 허용되지 않는 타입 → INVALID_CONTENT_TYPE")
+    void reissuePresignedUrl_invalidType_throwsException() {
+        assertThatThrownBy(() -> storageService.reissueChallengePresignedUrl("challenges/1/1/99_existing", "video/mp4"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_CONTENT_TYPE);
+
+        verify(s3Presigner, never()).presignPutObject(any(PutObjectPresignRequest.class));
+    }
+
+    // =========================================================================
+    // validateChallengeObjectMetadata — 사후 검증 (HeadObject)
+    // =========================================================================
+
+    @Test
+    @DisplayName("validateChallengeObjectMetadata - 객체 없음 → UPLOAD_NOT_COMPLETED")
+    void validate_objectNotFound_throwsUploadNotCompleted() {
+        when(s3Client.headObject(any(Consumer.class))).thenThrow(NoSuchKeyException.builder().build());
+
+        assertThatThrownBy(() -> storageService.validateChallengeObjectMetadata("challenges/1/1/100_uuid"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.UPLOAD_NOT_COMPLETED);
+    }
+
+    @Test
+    @DisplayName("validateChallengeObjectMetadata - 허용되지 않은 content-type → deleteObject 후 INVALID_CONTENT_TYPE")
+    void validate_invalidContentType_deletesObjectAndThrows() {
+        HeadObjectResponse head = HeadObjectResponse.builder()
+                .contentType("video/mp4")
+                .contentLength(1024L)
+                .build();
+        when(s3Client.headObject(any(Consumer.class))).thenReturn(head);
+
+        assertThatThrownBy(() -> storageService.validateChallengeObjectMetadata("challenges/1/1/100_uuid"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_CONTENT_TYPE);
+
+        verify(s3Client).deleteObject(any(software.amazon.awssdk.services.s3.model.DeleteObjectRequest.class));
+    }
+
+    @Test
+    @DisplayName("validateChallengeObjectMetadata - content-type 없음 → deleteObject 후 INVALID_CONTENT_TYPE")
+    void validate_nullContentType_deletesObjectAndThrows() {
+        HeadObjectResponse head = HeadObjectResponse.builder()
+                .contentLength(1024L)
+                .build();
+        when(s3Client.headObject(any(Consumer.class))).thenReturn(head);
+
+        assertThatThrownBy(() -> storageService.validateChallengeObjectMetadata("challenges/1/1/100_uuid"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_CONTENT_TYPE);
+
+        verify(s3Client).deleteObject(any(software.amazon.awssdk.services.s3.model.DeleteObjectRequest.class));
+    }
+
+    @Test
+    @DisplayName("validateChallengeObjectMetadata - 10MB 초과 → deleteObject 후 FILE_TOO_LARGE")
+    void validate_fileTooLarge_deletesObjectAndThrows() {
+        long overLimit = 10L * 1024 * 1024 + 1;
+        HeadObjectResponse head = HeadObjectResponse.builder()
+                .contentType("audio/webm")
+                .contentLength(overLimit)
+                .build();
+        when(s3Client.headObject(any(Consumer.class))).thenReturn(head);
+
+        assertThatThrownBy(() -> storageService.validateChallengeObjectMetadata("challenges/1/1/100_uuid"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FILE_TOO_LARGE);
+
+        verify(s3Client).deleteObject(any(software.amazon.awssdk.services.s3.model.DeleteObjectRequest.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"audio/webm", "audio/mp4", "audio/m4a", "audio/mpeg", "audio/wav"})
+    @DisplayName("validateChallengeObjectMetadata - 허용 타입 5종 + 정상 크기 → 예외 없음")
+    void validate_allowedTypes_noException(String contentType) {
+        HeadObjectResponse head = HeadObjectResponse.builder()
+                .contentType(contentType)
+                .contentLength(1024L * 1024)
+                .build();
+        when(s3Client.headObject(any(Consumer.class))).thenReturn(head);
+
+        assertThatCode(() -> storageService.validateChallengeObjectMetadata("challenges/1/1/100_uuid"))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
### Description

  챌린지 참여 API를 contentType 사전검증 + 업로드 완료 시 실제 S3 메타데이터 사후검증 구조로 재정렬했습니다.
  프론트가 녹음 전 알 수 없는 fileSize/fileName 의존성을 제거하면서도, 실제 업로드된 파일의 타입/크기는 서버가 최종 검증하도록 변경했습니다.

  ### Related Issues

  - Resolves #[283]

  ### Changes Made

  1. POST /challenges/{challengeId}/attempts 요청 바디를 contentType만 받도록 축소했습니다.
      - fileName, fileSize 제거
      - 허용 타입: audio/webm, audio/mp4, audio/m4a, audio/mpeg, audio/wav
      - MIME 파라미터 포함 값(audio/webm; codecs=opus)도 허용하도록 정규식 보완
  2. 챌린지 Presigned URL 발급 로직을 조정했습니다.
      - generateChallengePresignedUrl에서 contentType만 사전검증
      - objectKey를 확장자 없는 포맷으로 발급
      - PENDING 재시도 시 기존 objectKey를 재사용하는 reissueChallengePresignedUrl 추가
  3. 업로드 완료 시 실제 파일 메타데이터 검증을 강화했습니다.
      - HeadObject로 실제 content-type, content-length 확인
      - 객체 없음: UPLOAD_NOT_COMPLETED
      - 허용되지 않은 타입: INVALID_CONTENT_TYPE
      - 10MB 초과: FILE_TOO_LARGE
      - 잘못된 타입/크기 파일은 즉시 S3 삭제 시도
  4. Swagger 문서와 DTO 예시를 변경된 계약에 맞게 정리했습니다.
      - createAttempt 설명 업데이트
      - upload-complete 오류 설명 보강
      - objectKey 예시를 확장자 없는 포맷으로 통일
  5. 챌린지 업로드 흐름 관련 단위 테스트를 추가/보완했습니다.
      - ChallengeAttemptServiceTest
      - StorageServiceChallengeTest

  ### Screenshots or Video

  해당 없음

  ### Testing

  환경: local macOS, Java 21, Gradle

  1. ./gradlew test --tests '*ChallengeAttemptServiceTest' --tests '*StorageServiceChallengeTest'
  2. createAttempt 신규 생성 / PENDING 재발급 경로 검증
  3. HeadObject 기반 타입/크기 검증 및 invalid 파일 삭제 경로 검증

  ### Checklist

  - [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다.
  - [x] 관련 문서를 업데이트했습니다.
  - [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  - 챌린지 업로드 정책은 contentType은 사전검증, fileSize는 실제 업로드 파일 기준 사후검증으로 정리했습니다.
  - upload-complete를 호출하지 않은 PENDING 오브젝트 정리는 이번 PR 범위에 포함하지 않았습니다. 필요 시 후속 cleanup 작업이 가능합니다.