### PR TITLE
PR : Refactor/pvp-timer-scheduler

### DIFF
--- a/src/main/java/com/imyme/mine/domain/pvp/service/PvpAsyncService.java
+++ b/src/main/java/com/imyme/mine/domain/pvp/service/PvpAsyncService.java
@@ -15,30 +15,48 @@ import com.imyme.mine.global.messaging.MessagePublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 /**
  * PvP 비동기 작업 서비스
- * - @Async 프록시가 정상 작동하도록 별도 클래스로 분리
- * - sleep은 트랜잭션 밖에서 수행하여 DB 커넥션 점유 방지
- *   (@Async 메서드: sleep만 담당 / @Transactional 메서드: DB 작업만 담당)
+ *
+ * <p>Thread.sleep 대신 TaskScheduler 기반 예약 실행으로 스레드 블로킹을 제거한다.
+ * TimerKey + ConcurrentHashMap으로 예약 핸들을 관리하며, 재예약 시 이전 예약을 취소한다.
+ * stale 타이머 방어 로직(status 검증, startedAt 비교)은 doXxx 메서드에서 이중 안전장치로 유지된다.
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class PvpAsyncService {
 
-    private static final long RECORDING_TIMEOUT_MILLIS = 80_000L; // 1분 20초
+    private static final long THINKING_TRANSITION_MILLIS  = 3_000L;
+    private static final long RECORDING_TRANSITION_MILLIS = 30_000L;
+    private static final long RECORDING_TIMEOUT_MILLIS    = 80_000L;
+
+    /**
+     * 타이머 종류 — PvpRoomService에서 취소 시 사용
+     */
+    public enum TimerType {
+        THINKING_TRANSITION, RECORDING_TRANSITION, RECORDING_TIMEOUT
+    }
+
+    private record TimerKey(Long roomId, TimerType type) {}
 
     private final PvpRoomRepository pvpRoomRepository;
     private final PvpSubmissionRepository pvpSubmissionRepository;
@@ -47,29 +65,83 @@ public class PvpAsyncService {
     private final PvpMqConsumerService pvpMqConsumerService;
     private final com.imyme.mine.domain.pvp.websocket.PvpReadyManager pvpReadyManager;
 
-    // Self-injection: 내부 @Async / @Transactional 메서드 호출 시 프록시를 거치도록
-    // @Lazy: 순환 참조 방지
+    // @RequiredArgsConstructor로 @Qualifier를 지정할 수 없으므로 필드 주입
+    @Autowired
+    @Qualifier("pvpTimerScheduler")
+    private TaskScheduler taskScheduler;
+
+    // Self-injection: 내부 @Transactional 메서드 호출 시 프록시를 거치도록
     @Lazy
     @Autowired
     private PvpAsyncService self;
 
+    // 예약 핸들 맵 — 재예약·취소 시 이전 future 관리
+    private final ConcurrentHashMap<TimerKey, ScheduledFuture<?>> pendingTimers = new ConcurrentHashMap<>();
+
+    // ===== 타이머 예약 =====
+
     /**
-     * 3초 대기 후 THINKING 전환 위임
-     * - sleep은 트랜잭션 없이 수행
+     * 3초 후 THINKING 전환 예약
      */
-    @Async
     public void scheduleThinkingTransition(Long roomId) {
-        try {
-            Thread.sleep(3000);
-            self.doThinkingTransition(roomId);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("THINKING 전환 중단: roomId={}", roomId, e);
+        scheduleTimer(
+                new TimerKey(roomId, TimerType.THINKING_TRANSITION),
+                () -> self.doThinkingTransition(roomId),
+                THINKING_TRANSITION_MILLIS
+        );
+    }
+
+    /**
+     * 30초 후 RECORDING 전환 예약
+     * - thinkingStartedAt: stale 타이머 감지용 (게스트 재입장 시 이전 페이즈 타이머 스킵)
+     */
+    public void scheduleRecordingTransition(Long roomId, LocalDateTime thinkingStartedAt) {
+        scheduleTimer(
+                new TimerKey(roomId, TimerType.RECORDING_TRANSITION),
+                () -> self.doRecordingTransition(roomId, thinkingStartedAt),
+                RECORDING_TRANSITION_MILLIS
+        );
+    }
+
+    /**
+     * 80초 후 RECORDING 타임아웃 예약
+     */
+    public void scheduleRecordingTimeout(Long roomId) {
+        scheduleTimer(
+                new TimerKey(roomId, TimerType.RECORDING_TIMEOUT),
+                () -> self.doRecordingTimeout(roomId),
+                RECORDING_TIMEOUT_MILLIS
+        );
+    }
+
+    // ===== 타이머 취소 =====
+
+    /**
+     * 단건 취소
+     */
+    public void cancelTimer(Long roomId, TimerType type) {
+        TimerKey key = new TimerKey(roomId, type);
+        ScheduledFuture<?> future = pendingTimers.remove(key);
+        if (future != null) {
+            future.cancel(false);
+            log.info("[PvP 타이머] 취소: roomId={}, type={}", roomId, type);
         }
     }
 
     /**
-     * THINKING 전환 DB 작업 (트랜잭션 짧게 유지)
+     * 방 전체 타이머 취소 — 방 종료·게스트 이탈 시 호출
+     */
+    public void cancelAllTimers(Long roomId) {
+        for (TimerType type : TimerType.values()) {
+            cancelTimer(roomId, type);
+        }
+        log.info("[PvP 타이머] 전체 취소: roomId={}", roomId);
+    }
+
+    // ===== 상태 전환 메서드 =====
+
+    /**
+     * THINKING 전환 DB 작업
      * - 비관적 락: leaveRoom과 직렬화하여 낙관적 잠금 충돌 방지
      */
     @Transactional
@@ -100,42 +172,21 @@ public class PvpAsyncService {
         final var startedAt = room.getStartedAt();
         final var thinkingEndsAt = startedAt != null ? startedAt.plusSeconds(30) : null;
 
-        // 커밋 후 Redis Pub/Sub 발행 + RECORDING 타이머 예약
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                messagePublisher.publish(PvpChannels.getRoomChannel(roomId),
-                        PvpMessage.thinkingStarted(roomId, keywordId, keywordName, startedAt, thinkingEndsAt));
-                // startedAt을 함께 전달하여 게스트 재입장 시 stale 타이머 감지 가능
-                self.scheduleRecordingTransition(roomId, startedAt);
-            }
+        // 커밋 후 Redis Pub/Sub 발행 + RECORDING 전환 타이머 예약
+        afterCommit(() -> {
+            messagePublisher.publish(PvpChannels.getRoomChannel(roomId),
+                    PvpMessage.thinkingStarted(roomId, keywordId, keywordName, startedAt, thinkingEndsAt));
+            self.scheduleRecordingTransition(roomId, startedAt);
         });
     }
 
     /**
-     * 30초 대기 후 RECORDING 전환 위임
-     * - sleep은 트랜잭션 없이 수행
-     * - thinkingStartedAt: 게스트 퇴장 후 재입장 시 stale 타이머 감지용
-     */
-    @Async
-    public void scheduleRecordingTransition(Long roomId, java.time.LocalDateTime thinkingStartedAt) {
-        try {
-            Thread.sleep(30000);
-            self.doRecordingTransition(roomId, thinkingStartedAt);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("RECORDING 전환 중단: roomId={}", roomId, e);
-        }
-    }
-
-    /**
-     * RECORDING 전환 DB 작업 (트랜잭션 짧게 유지)
-     * - 비관적 락: leaveRoom과 직렬화하여 레이스 컨디션 방지 (Bug 1 fix)
-     * - expectedStartedAt: 게스트 퇴장 후 재입장 시 stale 타이머 감지 (Bug 2 fix)
+     * RECORDING 전환 DB 작업
+     * - 비관적 락: leaveRoom과 직렬화하여 레이스 컨디션 방지
+     * - expectedStartedAt: stale 타이머 감지 (게스트 퇴장 후 재입장 시 이전 페이즈 스킵)
      */
     @Transactional
-    public void doRecordingTransition(Long roomId, java.time.LocalDateTime expectedStartedAt) {
-        // Bug 1: 비관적 락으로 leaveRoom과 직렬화
+    public void doRecordingTransition(Long roomId, LocalDateTime expectedStartedAt) {
         PvpRoom room = pvpRoomRepository.findByIdWithDetailsForUpdate(roomId).orElse(null);
 
         if (room == null) {
@@ -150,7 +201,7 @@ public class PvpAsyncService {
             return;
         }
 
-        // Bug 2: 게스트 퇴장 후 새 게스트가 재입장한 경우, 이전 페이즈의 타이머는 스킵
+        // stale 타이머 방어: 다른 THINKING 페이즈의 타이머 스킵
         if (!expectedStartedAt.equals(room.getStartedAt())) {
             log.info("RECORDING 타이머 스킵: 다른 THINKING 페이즈 - roomId={}, expected={}, actual={}",
                     roomId, expectedStartedAt, room.getStartedAt());
@@ -171,28 +222,9 @@ public class PvpAsyncService {
         });
     }
 
-    // ===== RECORDING 타임아웃 =====
-
-    /**
-     * 80초 대기 후 RECORDING 타임아웃 처리
-     * - 미제출자가 있을 경우 자동으로 FAILED 처리 후 PROCESSING 전환
-     */
-    @Async
-    public void scheduleRecordingTimeout(Long roomId) {
-        try {
-            Thread.sleep(RECORDING_TIMEOUT_MILLIS);
-            self.doRecordingTimeout(roomId);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("RECORDING 타임아웃 중단: roomId={}", roomId, e);
-        }
-    }
-
     /**
      * RECORDING 타임아웃 핸들러
-     * - 비관적 락으로 방 조회
-     * - 미제출자 FAILED 처리 (레코드 없으면 생성, 동시성 방어)
-     * - 0명 제출: 방 취소 / 1명 이상 제출: PROCESSING 전환 + Feedback Request 발행
+     * - 미제출자 FAILED 처리 후 PROCESSING 또는 CANCELED 전환
      */
     @Transactional
     public void doRecordingTimeout(Long roomId) {
@@ -224,7 +256,6 @@ public class PvpAsyncService {
             PvpSubmission s = submissionMap.get(user.getId());
 
             if (s == null) {
-                // 제출 레코드 자체가 없으면 FAILED 레코드 생성
                 try {
                     PvpSubmission newS = PvpSubmission.builder()
                             .room(room)
@@ -234,14 +265,12 @@ public class PvpAsyncService {
                     pvpSubmissionRepository.save(newS);
                     log.info("[Timeout] 미제출 FAILED 레코드 생성: roomId={}, userId={}", roomId, user.getId());
                 } catch (DataIntegrityViolationException e) {
-                    // 동시에 누군가 제출 레코드를 만든 경우 → 무시
                     log.info("[Timeout] submission 동시 생성 감지: roomId={}, userId={}", roomId, user.getId());
                 }
                 continue;
             }
 
             if (s.getStatus() == PvpSubmissionStatus.PENDING) {
-                // presigned URL만 받고 제출 안 한 경우
                 s.fail();
                 pvpSubmissionRepository.save(s);
                 log.info("[Timeout] PENDING → FAILED: roomId={}, userId={}", roomId, user.getId());
@@ -253,7 +282,6 @@ public class PvpAsyncService {
         }
 
         if (submittedCount == 0) {
-            // 양쪽 모두 미제출 → 방 취소
             room.cancel();
             pvpRoomRepository.save(room);
             log.info("[Timeout] 양쪽 미제출 → CANCELED: roomId={}", roomId);
@@ -274,7 +302,6 @@ public class PvpAsyncService {
         // 트랜잭션 안에서 Feedback Request 발행 (비관적 락 필요)
         pvpMqConsumerService.tryPublishFeedbackRequest(roomId);
 
-        // afterCommit은 브로드캐스트만
         afterCommit(() ->
                 messagePublisher.publish(PvpChannels.getRoomChannel(roomId),
                         PvpMessage.statusChange(roomId, PvpRoomStatus.PROCESSING,
@@ -282,7 +309,39 @@ public class PvpAsyncService {
         );
     }
 
-    // ===== Helper =====
+    // ===== 내부 헬퍼 =====
+
+    /**
+     * 타이머 예약 — 재예약 시 이전 future 취소, 늦은 실행 시 map 무결성 보장
+     *
+     * <p>AtomicReference로 currentFuture를 캡처하여 pendingTimers.remove(key, currentFuture)를 수행한다.
+     * 재예약으로 map이 교체된 뒤 이전 Runnable이 늦게 실행되더라도 새 future 매핑을 덮어쓰지 않는다.
+     */
+    private void scheduleTimer(TimerKey key, Runnable task, long delayMillis) {
+        ScheduledFuture<?> oldFuture = pendingTimers.remove(key);
+        if (oldFuture != null) {
+            oldFuture.cancel(false);
+            log.debug("[PvP 타이머] 기존 예약 취소 후 재예약: key={}", key);
+        }
+
+        AtomicReference<ScheduledFuture<?>> futureRef = new AtomicReference<>();
+        ScheduledFuture<?> newFuture = taskScheduler.schedule(
+                () -> {
+                    pendingTimers.remove(key, futureRef.get());
+                    task.run();
+                },
+                Instant.now().plusMillis(delayMillis)
+        );
+
+        if (newFuture == null) {
+            log.warn("[PvP 타이머] 예약 실패 (null 반환): key={}", key);
+            return;
+        }
+
+        futureRef.set(newFuture);
+        pendingTimers.put(key, newFuture);
+        log.info("[PvP 타이머] 예약 완료: key={}, delayMs={}", key, delayMillis);
+    }
 
     private void afterCommit(Runnable action) {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {

--- a/src/main/java/com/imyme/mine/domain/pvp/service/PvpRoomService.java
+++ b/src/main/java/com/imyme/mine/domain/pvp/service/PvpRoomService.java
@@ -210,8 +210,13 @@ public class PvpRoomService {
 
         log.info("게스트 입장: roomId={}, userId={}, status=MATCHED", roomId, userId);
 
-        // 3초 후 키워드 배정 및 THINKING 전환 (비동기)
-        pvpAsyncService.scheduleThinkingTransition(roomId);
+        // 커밋 후 3초 타이머 예약 (커밋 전 예약 시 롤백돼도 타이머가 실행될 수 있으므로 afterCommit에서 등록)
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                pvpAsyncService.scheduleThinkingTransition(roomId);
+            }
+        });
 
         return toRoomResponse(room, "매칭 완료! 잠시 후 키워드가 공개됩니다.");
     }
@@ -267,10 +272,11 @@ public class PvpRoomService {
             pvpReadyManager.clearReady(roomId);
             log.info("양쪽 READY → RECORDING 즉시 전환: roomId={}", roomId);
 
-            // 커밋 후 RECORDING 브로드캐스트 + 타임아웃 예약
+            // 커밋 후 RECORDING_TRANSITION 타이머 취소 + 브로드캐스트 + 타임아웃 예약
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
+                    pvpAsyncService.cancelTimer(roomId, PvpAsyncService.TimerType.RECORDING_TRANSITION);
                     messagePublisher.publish(PvpChannels.getRoomChannel(roomId),
                             PvpMessage.recordingStarted(roomId));
                     pvpAsyncService.scheduleRecordingTimeout(roomId);
@@ -439,10 +445,11 @@ public class PvpRoomService {
             // - AI 서버가 Feedback Response 반환
             // - Feedback Response Consumer에서 승패 결정 및 결과 저장
 
-            // PROCESSING 브로드캐스트 (커밋 후 Redis Pub/Sub)
+            // RECORDING_TIMEOUT 타이머 취소 + PROCESSING 브로드캐스트 (커밋 후 Redis Pub/Sub)
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
+                    pvpAsyncService.cancelTimer(currentRoomId, PvpAsyncService.TimerType.RECORDING_TIMEOUT);
                     messagePublisher.publish(PvpChannels.getRoomChannel(currentRoomId),
                             PvpMessage.statusChange(currentRoomId, PvpRoomStatus.PROCESSING, "양쪽 모두 제출 완료! AI 분석이 시작됩니다."));
                 }
@@ -511,6 +518,13 @@ public class PvpRoomService {
             room.cancel();
             pvpRoomRepository.save(room);
             log.info("호스트 방 나가기: roomId={}, status=CANCELED", roomId);
+
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    pvpAsyncService.cancelAllTimers(roomId);
+                }
+            });
             return new LeaveResult(roomId, LeaveType.HOST_LEFT, PvpRoomStatus.CANCELED);
 
         } else {
@@ -525,6 +539,13 @@ public class PvpRoomService {
             pvpRoomRepository.save(room);
             pvpReadyManager.clearReady(roomId);
             log.info("게스트 방 나가기: roomId={}, status=OPEN", roomId);
+
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    pvpAsyncService.cancelAllTimers(roomId);
+                }
+            });
             return new LeaveResult(roomId, LeaveType.GUEST_LEFT, PvpRoomStatus.OPEN);
         }
     }

--- a/src/main/java/com/imyme/mine/global/config/PvpSchedulerConfig.java
+++ b/src/main/java/com/imyme/mine/global/config/PvpSchedulerConfig.java
@@ -1,0 +1,45 @@
+package com.imyme.mine.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * 스케줄러 Bean 설정
+ *
+ * <p>두 개의 스케줄러를 분리하여 PvP 타이머가 전역 @Scheduled 잡 실행기에 영향을 주지 않도록 한다.
+ * Spring의 ScheduledAnnotationBeanPostProcessor는 "taskScheduler" 이름의 Bean을 우선 탐색하므로,
+ * pvpTimerScheduler 추가만으로는 기존 @Scheduled 잡 실행기가 바뀌지 않는다.
+ */
+@Configuration
+public class PvpSchedulerConfig {
+
+    /**
+     * 전역 @Scheduled 잡 전용 스케줄러
+     * - RetentionScheduler, AttemptExpirationScheduler 등이 사용
+     * - 기존 Spring Boot 기본 동작과 동일하게 단일 스레드로 유지
+     */
+    @Bean("taskScheduler")
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.setThreadNamePrefix("scheduled-");
+        scheduler.initialize();
+        return scheduler;
+    }
+
+    /**
+     * PvP 타이머 전용 스케줄러
+     * - scheduleThinkingTransition / scheduleRecordingTransition / scheduleRecordingTimeout 에서만 사용
+     * - removeOnCancelPolicy: 취소된 작업을 큐에서 즉시 제거하여 메모리 누수 방지
+     */
+    @Bean("pvpTimerScheduler")
+    public ThreadPoolTaskScheduler pvpTimerScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(4);
+        scheduler.setThreadNamePrefix("pvp-timer-");
+        scheduler.setRemoveOnCancelPolicy(true);
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/src/test/java/com/imyme/mine/domain/pvp/service/PvpAsyncServiceTimerTest.java
+++ b/src/test/java/com/imyme/mine/domain/pvp/service/PvpAsyncServiceTimerTest.java
@@ -1,0 +1,182 @@
+package com.imyme.mine.domain.pvp.service;
+
+import com.imyme.mine.domain.keyword.repository.KeywordRepository;
+import com.imyme.mine.domain.pvp.repository.PvpRoomRepository;
+import com.imyme.mine.domain.pvp.repository.PvpSubmissionRepository;
+import com.imyme.mine.domain.pvp.websocket.PvpReadyManager;
+import com.imyme.mine.global.messaging.MessagePublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DisplayName("PvpAsyncService 타이머 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class PvpAsyncServiceTimerTest {
+
+    @Mock TaskScheduler taskScheduler;
+    @Mock PvpAsyncService selfMock;
+
+    @Mock PvpRoomRepository pvpRoomRepository;
+    @Mock PvpSubmissionRepository pvpSubmissionRepository;
+    @Mock KeywordRepository keywordRepository;
+    @Mock MessagePublisher messagePublisher;
+    @Mock PvpMqConsumerService pvpMqConsumerService;
+    @Mock PvpReadyManager pvpReadyManager;
+
+    @Mock ScheduledFuture future1;
+    @Mock ScheduledFuture future2;
+
+    PvpAsyncService pvpAsyncService;
+
+    @BeforeEach
+    void setUp() {
+        pvpAsyncService = new PvpAsyncService(
+                pvpRoomRepository, pvpSubmissionRepository, keywordRepository,
+                messagePublisher, pvpMqConsumerService, pvpReadyManager
+        );
+        ReflectionTestUtils.setField(pvpAsyncService, "taskScheduler", taskScheduler);
+        ReflectionTestUtils.setField(pvpAsyncService, "self", selfMock);
+    }
+
+    // =========================================================================
+    // 예약 기본 동작
+    // =========================================================================
+
+    @Test
+    @DisplayName("scheduleThinkingTransition - schedule() 1회 호출")
+    void scheduleThinkingTransition_callsScheduleOnce() {
+        when(taskScheduler.schedule(any(Runnable.class), any(Instant.class))).thenReturn(future1);
+
+        pvpAsyncService.scheduleThinkingTransition(1L);
+
+        verify(taskScheduler, times(1)).schedule(any(Runnable.class), any(Instant.class));
+    }
+
+    @Test
+    @DisplayName("Runnable 실행 시 self.doThinkingTransition() 호출")
+    void runnableExecution_callsDoThinkingTransition() {
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        when(taskScheduler.schedule(runnableCaptor.capture(), any(Instant.class))).thenReturn(future1);
+
+        pvpAsyncService.scheduleThinkingTransition(42L);
+        runnableCaptor.getValue().run();
+
+        verify(selfMock).doThinkingTransition(42L);
+    }
+
+    // =========================================================================
+    // 재예약 — 이전 future 취소
+    // =========================================================================
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @DisplayName("재예약 시 이전 future cancel(false) 호출")
+    void reschedule_cancelsPreviousFuture() {
+        when(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                .thenReturn(future1)
+                .thenReturn(future2);
+
+        pvpAsyncService.scheduleThinkingTransition(1L);
+        pvpAsyncService.scheduleThinkingTransition(1L);
+
+        verify(future1).cancel(false);
+    }
+
+    // =========================================================================
+    // 취소 — map 정리
+    // =========================================================================
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @DisplayName("cancelTimer - future 취소 + pendingTimers에서 제거")
+    void cancelTimer_cancelsFutureAndRemovesFromMap() {
+        when(taskScheduler.schedule(any(Runnable.class), any(Instant.class))).thenReturn(future1);
+        pvpAsyncService.scheduleThinkingTransition(1L);
+
+        pvpAsyncService.cancelTimer(1L, PvpAsyncService.TimerType.THINKING_TRANSITION);
+
+        verify(future1).cancel(false);
+        ConcurrentHashMap<?, ?> pendingTimers =
+                (ConcurrentHashMap<?, ?>) ReflectionTestUtils.getField(pvpAsyncService, "pendingTimers");
+        assertThat(pendingTimers).isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @DisplayName("cancelAllTimers - 모든 타입 future 취소 + map 비움")
+    void cancelAllTimers_cancelsAllAndClearsMap() {
+        when(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                .thenReturn(future1)
+                .thenReturn(future2)
+                .thenReturn(mock(ScheduledFuture.class));
+
+        pvpAsyncService.scheduleThinkingTransition(1L);
+        pvpAsyncService.scheduleRecordingTransition(1L, java.time.LocalDateTime.now());
+        pvpAsyncService.scheduleRecordingTimeout(1L);
+
+        pvpAsyncService.cancelAllTimers(1L);
+
+        verify(future1).cancel(false);
+        verify(future2).cancel(false);
+        ConcurrentHashMap<?, ?> pendingTimers =
+                (ConcurrentHashMap<?, ?>) ReflectionTestUtils.getField(pvpAsyncService, "pendingTimers");
+        assertThat(pendingTimers).isEmpty();
+    }
+
+    // =========================================================================
+    // 늦은 Runnable — 새 future 매핑 보호
+    // =========================================================================
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @DisplayName("이전 Runnable이 늦게 실행돼도 새 future 매핑 유지")
+    void lateRunnable_doesNotRemoveNewFutureFromMap() {
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        when(taskScheduler.schedule(runnableCaptor.capture(), any(Instant.class)))
+                .thenReturn(future1)
+                .thenReturn(future2);
+
+        pvpAsyncService.scheduleThinkingTransition(1L);
+        pvpAsyncService.scheduleThinkingTransition(1L); // 재예약 → future2가 map에 등록됨
+
+        Runnable oldRunnable = runnableCaptor.getAllValues().get(0);
+        oldRunnable.run(); // 이전 Runnable이 늦게 실행됨
+
+        // 새 future2 매핑은 그대로 유지되어야 함
+        ConcurrentHashMap<?, ScheduledFuture<?>> pendingTimers =
+                (ConcurrentHashMap<?, ScheduledFuture<?>>) ReflectionTestUtils.getField(pvpAsyncService, "pendingTimers");
+        assertThat(pendingTimers).hasSize(1);
+        assertThat(pendingTimers.values()).contains(future2);
+    }
+
+    // =========================================================================
+    // null future 방어
+    // =========================================================================
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @DisplayName("schedule() null 반환 시 pendingTimers에 등록되지 않음")
+    void nullFuture_notAddedToMap() {
+        when(taskScheduler.schedule(any(Runnable.class), any(Instant.class))).thenReturn(null);
+
+        pvpAsyncService.scheduleThinkingTransition(1L);
+
+        ConcurrentHashMap<?, ?> pendingTimers =
+                (ConcurrentHashMap<?, ?>) ReflectionTestUtils.getField(pvpAsyncService, "pendingTimers");
+        assertThat(pendingTimers).isEmpty();
+    }
+}


### PR DESCRIPTION
### Description

  PvP 대기 타이머를 `@Async + Thread.sleep` 기반 구현에서 `TaskScheduler` 기반 예약 실행 방식으로 교체했습니다.

  기존 구현은 게임 진행 중 `THINKING`, `RECORDING`, `RECORDING_TIMEOUT` 타이머마다 sleep 중인 스레드를 점유하고 있어, 동시 방 수가 증가할수록 live thread 수가
  불필요하게 증가하는 문제가 있었습니다. 이번 변경으로 지연 실행을 예약 방식으로 전환해 스레드 블로킹을 제거하고, 방 단위 타이머 취소/재예약을 명시적으로 관리하
  도록 구조를 정리했습니다.

  ### Related Issues

  - Resolves #[285]

  ### Changes Made

  1. PvP 타이머 전용 `TaskScheduler`를 추가하고, 기존 전역 `@Scheduled` 작업과 분리했습니다.
  2. `PvpAsyncService`의 `Thread.sleep` 기반 타이머를 `TaskScheduler.schedule()` 기반 예약 실행으로 교체하고, `TimerKey + ScheduledFuture` 관리 구조를 도입했습
  니다.
  3. `PvpRoomService`에서 상태 전환 및 방 종료 흐름에 맞춰 타이머 예약/취소를 `afterCommit` 시점에 연결했습니다.
  4. `PvpAsyncServiceTimerTest`를 추가해 재예약 시 기존 future 취소, map 정리, late runnable 안전성, self 위임 호출을 검증했습니다.

  ### Screenshots or Video

  - UI 변경 없음

  ### Testing

  1. `./gradlew compileJava`
  2. `./gradlew test --tests com.imyme.mine.domain.pvp.service.PvpAsyncServiceTimerTest`
  3. 코드 리뷰 기준으로 다음 흐름을 점검했습니다.
     - 매칭 후 `THINKING` 타이머 예약
     - 양쪽 READY 시 `RECORDING_TRANSITION` 취소 후 `RECORDING_TIMEOUT` 예약
     - 제출 완료 및 방 종료 시 관련 타이머 취소

  ### Checklist

  - [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  - 기대 효과는 응답 시간 개선보다 `sleep` 제거에 따른 JVM live thread 감소입니다.
  - 운영 검증 시 `jvm_threads_live_threads`를 Grafana/Prometheus에서 함께 확인하는 것을 권장합니다.
  - 현재 범위는 PvP 타이머 예약 구조 개선이며, 커스텀 메트릭(`timer_transition_canceled` 등)은 포함하지 않았습니다.