### PR TITLE
PR : Refactor/pvp-room-list-fetch-join

### DIFF
--- a/src/main/java/com/imyme/mine/domain/pvp/repository/PvpRoomRepository.java
+++ b/src/main/java/com/imyme/mine/domain/pvp/repository/PvpRoomRepository.java
@@ -26,6 +26,9 @@ public interface PvpRoomRepository extends JpaRepository<PvpRoom, Long> {
      */
     @Query("""
             SELECT r FROM PvpRoom r
+            LEFT JOIN FETCH r.category
+            LEFT JOIN FETCH r.hostUser
+            LEFT JOIN FETCH r.guestUser
             WHERE r.category.id = :categoryId
             AND r.status = :status
             ORDER BY r.createdAt DESC, r.id DESC
@@ -41,6 +44,9 @@ public interface PvpRoomRepository extends JpaRepository<PvpRoom, Long> {
      */
     @Query("""
             SELECT r FROM PvpRoom r
+            LEFT JOIN FETCH r.category
+            LEFT JOIN FETCH r.hostUser
+            LEFT JOIN FETCH r.guestUser
             WHERE r.category.id = :categoryId
             AND r.status = :status
             AND (r.createdAt < :cursor OR (r.createdAt = :cursor AND r.id < :lastId))
@@ -59,6 +65,9 @@ public interface PvpRoomRepository extends JpaRepository<PvpRoom, Long> {
      */
     @Query("""
             SELECT r FROM PvpRoom r
+            LEFT JOIN FETCH r.category
+            LEFT JOIN FETCH r.hostUser
+            LEFT JOIN FETCH r.guestUser
             WHERE r.status = :status
             ORDER BY r.createdAt DESC, r.id DESC
             """)
@@ -72,6 +81,9 @@ public interface PvpRoomRepository extends JpaRepository<PvpRoom, Long> {
      */
     @Query("""
             SELECT r FROM PvpRoom r
+            LEFT JOIN FETCH r.category
+            LEFT JOIN FETCH r.hostUser
+            LEFT JOIN FETCH r.guestUser
             WHERE r.status = :status
             AND (r.createdAt < :cursor OR (r.createdAt = :cursor AND r.id < :lastId))
             ORDER BY r.createdAt DESC, r.id DESC


### PR DESCRIPTION
 ### Description

  PvP 방 목록 조회에서 발생하던 N+1 쿼리 문제를 해결하기 위해 목록 조회 쿼리에 `FETCH JOIN`을 적용했습니다.

  기존에는 `PvpRoomService#getRooms()`가 호출하는 목록 조회 쿼리들이 `PvpRoom`만 조회한 뒤, `toRoomItem()` 변환 과정에서 `category`, `hostUser`, `guestUser`에 대한 Lazy Loading이 연쇄적으로 발
  생했습니다. 이번 변경으로 목록 조회 단계에서 필요한 연관 엔티티를 함께 조회하도록 바꿔 요청당 SQL 수를 줄이고 응답 지연을 낮췄습니다.

  ### Related Issues

  - Resolves #[289]

  ### Changes Made

  1. `PvpRoomRepository`의 방 목록 조회 4개 쿼리(`findRoomsByStatus`, `findRoomsByStatusWithCursor`, `findRoomsByCategoryAndStatus`, `findRoomsByCategoryAndStatusWithCursor`)에 `FETCH JOIN`을
  추가했습니다.
  2. `getRooms()` 경로에서 `category`, `hostUser`, `guestUser`가 추가 SELECT 없이 조회되도록 최적화했습니다.
  3. 로컬 QueryCount 로그, Sentry, k6 기준으로 Before/After 성능을 비교해 N+1 제거 효과를 확인했습니다.

  ### Screenshots or Video

  - UI 변경 없음

  ### Testing

  1. `./gradlew compileJava`
  2. 로컬 `dev` 환경에서 QueryCount 로그로 `GET /pvp/rooms` 요청당 SQL 수 비교
  3. k6 및 Sentry 기준으로 방 목록 조회 응답시간 Before/After 비교

  ### Checklist

  - [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [ ] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.
  - [ ] 코드 리뷰어를 지정했습니다.

  ### Additional Notes

  | **구분** | **지표** | **Before (Lazy Loading)** | **After (FETCH JOIN)** | **개선율** |
  | --- | --- | --- | --- | --- |
  | **효율성** | **호출당 쿼리 수** | 10개 (방 3개 기준) | **1개** | **90% ↓** |
  | **안정성** | **Sentry p95** | 250ms (변동폭 큼) | **30ms 이하** | **88% ↓** |
  | **최대 지연** | **Sentry p99** | 300ms 이상 | **90ms 이하** | **70% ↓** |
  | **부하 테스트** | **k6 p95** | 27.22ms | **17.29ms** | **36% ↓** |
  | **평균 속도** | **k6 Avg** | 10.45ms | **7.85ms** | **25% ↓** |

  - 이번 변경은 API 응답 형식 변경 없이 조회 성능만 개선하는 리팩토링입니다.
  - 핵심 효과는 방 목록 조회 시 연쇄 Lazy Loading 제거로 인한 DB round trip 감소입니다.
  - 성능 개선은 요청당 쿼리 수 감소와 p95/p99 응답시간 안정화에서 확인했습니다.