### PR TITLE
feat/infra: 로그 포멧 변경

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -61,3 +61,8 @@ logging:
         com.imyme.mine: DEBUG
         org.flywaydb: INFO
         org.springframework.amqp: DEBUG  # RabbitMQ 디버깅
+
+sentry:
+    environment: dev
+    debug: false
+    traces-sample-rate: 1.0

--- a/src/main/resources/application-release.yml
+++ b/src/main/resources/application-release.yml
@@ -73,7 +73,7 @@ spring:
 logging:
     level:
         root: INFO
-        com.imyme.mine: DEBUG  # Prod보다는 상세한 로그 (디버깅용)
+        com.imyme.mine: INFO
         org.springframework.security: INFO
         org.hibernate.SQL: WARN
 
@@ -85,3 +85,9 @@ solo:
 knowledge:
     batch:
         enabled: false  # 필요 시 true로 변경
+
+# Sentry 설정 (Release 환경용)
+sentry:
+    environment: release
+    debug: false
+    traces-sample-rate: 0.1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -231,7 +231,7 @@ sentry:
     environment: local
     traces-sample-rate: 1.0  # 테스트용 100% 샘플링
     send-default-pii: false
-    debug: true  # 디버그 로그 활성화
+    debug: false
     logging:
         minimum-event-level: error
         minimum-breadcrumb-level: info

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,8 +6,8 @@
     <springProfile name="local,default,dev">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <!-- 단순하고 명확한 로그 패턴 (컬러 없이) -->
-                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%5p] [%15.15t] %-40.40logger{39} : %m%n%ex{full}</pattern>
+                <!-- 로컬/개발 환경에서 읽기 쉬운 텍스트 로그 -->
+                <pattern>%d{HH:mm:ss.SSS} [%5p] [%20.20t] %-36.36logger{36} - %m%n%ex{10}</pattern>
                 <charset>UTF-8</charset>
             </encoder>
         </appender>
@@ -30,8 +30,8 @@
 
         <!-- 개발할 때 유용한 로거들 -->
         <logger name="com.imyme.mine" level="DEBUG"/>
-        <logger name="org.springframework.security" level="DEBUG"/>
-        <logger name="org.springframework.web" level="DEBUG"/>
+        <logger name="org.springframework.security" level="INFO"/>
+        <logger name="org.springframework.web" level="INFO"/>
 <!--        <logger name="org.hibernate.SQL" level="DEBUG"/>-->
 <!--        <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE"/>-->
 <!--        <logger name="org.springframework.transaction" level="DEBUG"/>-->


### PR DESCRIPTION
## 변경 사항
- `release` 환경을 `prod`와 동일한 Sentry 동작으로 정렬
- `release` 앱 로그 레벨을 `INFO`로 조정
- `dev/local` 로그 가독성 개선 및 Sentry 디버그 노이즈 제거

---

## 상세 변경 내용

### application-release.yml
- `sentry.environment: release`
- `sentry.debug: false`
- `sentry.traces-sample-rate: 0.1`
- `logging.level.com.imyme.mine: INFO`

### application-dev.yml
- `sentry.environment: dev`
- `sentry.debug: false`
- `sentry.traces-sample-rate: 1.0`

### application.yml
- `sentry.debug: false` (기본값 설정)

### logback-spring.xml
- `local/dev` 콘솔 로그 패턴 가독성 개선
- `org.springframework.security.web` 로그 레벨 `DEBUG → INFO` 조정

---

## 기대 효과
- `release` 환경에서 `local` 태그 및 디버그성 Sentry 로그 출력 문제 해소
- `local/dev` 환경에서 로그 가독성 개선
- 불필요한 보안 로그 감소로 실제 이슈 파악 용이