### PR TITLE
fix: jti 제거 및 동시 로그인 테스트 sleep 추가

### DIFF
--- a/src/main/java/com/imyme/mine/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/imyme/mine/global/security/jwt/JwtTokenProvider.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
-import java.util.UUID;
 
 /**
  * JWT 토큰 생성 및 검증
@@ -35,7 +34,6 @@ public class JwtTokenProvider {
         Date expiryDate = new Date(now.getTime() + jwtProperties.getAccessTokenExpiration());
 
         return Jwts.builder()
-            .id(UUID.randomUUID().toString())
             .subject(String.valueOf(userId))
             .issuedAt(now)
             .expiration(expiryDate)
@@ -49,7 +47,6 @@ public class JwtTokenProvider {
         Date expiryDate = new Date(now.getTime() + jwtProperties.getRefreshTokenExpiration());
 
         return Jwts.builder()
-            .id(UUID.randomUUID().toString())
             .subject(String.valueOf(userId))
             .issuedAt(now)
             .expiration(expiryDate)

--- a/src/test/java/com/imyme/mine/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/imyme/mine/acceptance/AuthAcceptanceTest.java
@@ -78,13 +78,15 @@ class AuthAcceptanceTest extends IntegrationTestSupport {
 
     @Test
     @DisplayName("동일 디바이스로 두 번 로그인 - 모두 성공 (세션 재사용 정책)")
-    void e2eLogin_sameDevice_bothSucceed() {
+    void e2eLogin_sameDevice_bothSucceed() throws InterruptedException {
         // given
         String url = "http://localhost:" + port + "/e2e/login";
         Map<String, String> request = Map.of("deviceUuid", "550e8400-e29b-41d4-a716-446655440001");
 
         // when
+        Thread.sleep(1100); // 이전 테스트와 초(second)가 달라지도록 대기 (JWT는 초 단위 정밀도)
         ResponseEntity<Map> first = restTemplate.postForEntity(url, request, Map.class);
+        Thread.sleep(1100); // 동일 초 내 JWT 중복 생성 방지
         ResponseEntity<Map> second = restTemplate.postForEntity(url, request, Map.class);
 
         // then


### PR DESCRIPTION
### Description

  Testcontainers 통합 테스트 도입 과정에서 추가한 `jti`(JWT ID) claim이 프론트엔드 싱글플라이트 환경에서 RTR(Refresh Token Rotation) 충돌을 유발하는 문제를
  수정합니다. `jti` 제거 후 테스트 코드에 sleep을 추가해 토큰 중복 생성 문제를 방지합니다.

  ### Related Issues

  - Resolves #296 CD 배포 후 `/auth/refresh` 반복 호출 문제

  ### Changes Made

  1. `JwtTokenProvider`에서 `jti`(UUID) claim 제거
     - 프론트엔드가 싱글플라이트로 처리하고 있었으나, `jti` 도입으로 매번 다른 토큰이 생성되면서 RTR 충돌이 발생해 `/auth/refresh` 반복 호출 유발
  2. `AuthAcceptanceTest.e2eLogin_sameDevice_bothSucceed`에 `Thread.sleep(1100)` 추가
     - JWT는 초(second) 단위 정밀도라 같은 초 안에 동일 유저에 대해 토큰을 생성하면 동일한 JWT 생성 → `uk_sessions_refresh_token` unique constraint 충돌
     - 각 로그인 호출 사이에 sleep을 추가해 서로 다른 초에 토큰이 생성되도록 보장

  ### Testing

  1. `./gradlew test` 84개 테스트 전체 통과 확인
  2. dev 서버 배포 후 `/auth/refresh` 반복 호출 여부 확인 필요

  ### Checklist

  - [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
  - [x] 모든 테스트가 성공적으로 통과했습니다.
  - [ ] 관련 문서를 업데이트했습니다.
  - [x] 코드 스타일 가이드라인을 준수했습니다.

  ### Additional Notes

  `jti` 도입 이전에는 같은 초 안에 동일 유저의 토큰을 생성하면 동일한 JWT가 생성되어 동시 refresh 요청이 동일한 해시값을 생성, RTR 충돌이 없었습니다. `jti` 추가 후
  매번 고유한 토큰이 생성되면서 기존에 숨겨져 있던 동시 refresh 문제가 드러났습니다. 근본적인 해결은 프론트엔드 싱글플라이트 로직 강화이며, 백엔드는 이전 동작으로
  복구합니다.