### PR TITLE
PR: Fix : 챌린지 STT 메시지 역직렬화 버그 수정

### DIFF
--- a/src/main/java/com/imyme/mine/domain/challenge/dto/message/ChallengeFeedbackResponseDto.java
+++ b/src/main/java/com/imyme/mine/domain/challenge/dto/message/ChallengeFeedbackResponseDto.java
@@ -2,6 +2,7 @@ package com.imyme.mine.domain.challenge.dto.message;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * AI 서버 → Spring: 챌린지 STT 응답 MQ DTO
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
  * status = "FAIL"인 경우 sttText는 null일 수 있음.
  */
 @Getter
+@Setter
 @NoArgsConstructor
 public class ChallengeFeedbackResponseDto {
 


### PR DESCRIPTION
## 변경 사항
- ChallengeFeedbackResponseDto에 @Setter 추가

## 목적
- @Setter가 없어서 Jackson이 MQ 메시지를 역직렬화할 때 필드 값을 설정하지 못함
- sttText가 null/빈 문자열로 저장되던 버그 해결